### PR TITLE
util: Support jsonencode/jsondecode as regular functions

### DIFF
--- a/+bids/+util/jsondecode.m
+++ b/+bids/+util/jsondecode.m
@@ -12,9 +12,15 @@ function value = jsondecode(file, varargin)
 % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
+persistent has_jsondecode
+if isempty(has_jsondecode)
+    has_jsondecode = ...
+        exist('jsondecode','builtin') == 5 || ...       % MATLAB >= R2016b
+        ismember(exist('jsondecode','file'), [2 3]);    % jsonstuff or other Matlab-compatible implementation
+end
 
-if exist('jsondecode','builtin') == 5               % MATLAB >= R2016b
-    value = builtin('jsondecode', fileread(file));
+if has_jsondecode
+    value = jsondecode(fileread(file));
 elseif exist('spm_jsonread','file') == 3            % SPM12
     value = spm_jsonread(file, varargin{:});
 elseif exist('jsonread','file') == 3                % JSONio

--- a/+bids/+util/jsonencode.m
+++ b/+bids/+util/jsonencode.m
@@ -19,16 +19,22 @@ function varargout = jsonencode(varargin)
 % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
-
 if ~nargin
     error('Not enough input arguments.');
+end
+
+persistent has_jsonencode
+if isempty(has_jsonencode)
+    has_jsonencode = ...
+        exist('jsonencode','builtin') == 5 || ...       % MATLAB >= R2016b
+        ismember(exist('jsonencode','file'), [2 3]);    % jsonstuff or other Matlab-compatible implementation
 end
 
 if exist('spm_jsonwrite','file') == 2                    % SPM12
     [varargout{1:nargout}] = spm_jsonwrite(varargin{:});
 elseif exist('jsonwrite','file') == 2                    % JSONio
     [varargout{1:nargout}] = jsonwrite(varargin{:});
-elseif exist('jsonencode','builtin') == 5                % MATLAB >= R2016b
+elseif has_jsonencode
     file = '';
     if ischar(varargin{1})
         file = varargin{1};
@@ -44,7 +50,7 @@ elseif exist('jsonencode','builtin') == 5                % MATLAB >= R2016b
             end
         end
     end
-    txt = builtin('jsonencode', varargin{:});
+    txt = jsonencode(varargin{:});
     if ~isempty(file)
         fid = fopen(file,'wt');
         if fid == -1


### PR DESCRIPTION
What do you think about supporting jsonencode/jsondecode when implemented as regular functions, in addition to just when they're built-ins? This would allow the jsonencode/jsondecode from jsonstuff (https://github.com/apjanke/octave-jsonstuff) or any other Matlab-compatible implementation to be used, in addition to JSONio. This would be nice for me because I'd rather use jsonstuff than JSONio. And there's a chance that jsonencode/jsondecode will eventually get merged into Octave core from one of these libraries, but might be regular functions instead of builtins there, so this would be forward-looking for future Octave versions. (Also, Matlab could always change the jsonencode/jsondecode implementation to use regular M-file wrapper functions, which would break the current detection.)