### PR TITLE
Move +bids/private stuff to +bids/+internal?

### DIFF
--- a/+bids/+internal/README.md
+++ b/+bids/+internal/README.md
@@ -1,0 +1,6 @@
+BIDS-MATLAB +internal package
+=============================
+
+This package contains functions for BIDS-MATLAB's internal use only.
+
+Do not call these functions directly from your code! They are undocumented and subject to change at any time. If you call these functions from your code, your code may break or produce incorrect results!

--- a/+bids/+internal/file_utils.m
+++ b/+bids/+internal/file_utils.m
@@ -1,11 +1,11 @@
 function varargout = file_utils(str,varargin)
 % Character array (or cell array of strings) handling facility
-% FORMAT str = file_utils(str,option)
+% FORMAT str = bids.internal.file_utils(str,option)
 % str        - character array, or cell array of strings
 % option     - string of requested item - one among:
 %              {'path', 'basename', 'ext', 'filename', 'cpath', 'fpath'}
 %
-% FORMAT str = file_utils(str,opt_key,opt_val,...)
+% FORMAT str = bids.internal.file_utils(str,opt_key,opt_val,...)
 % str        - character array, or cell array of strings
 % opt_key    - string of targeted item - one among:
 %              {'path', 'basename', 'ext', 'filename', 'prefix', 'suffix'}
@@ -192,7 +192,7 @@ end
 if nargin < 2
     d = pwd;
 else
-    d = file_utils(d,'cpath');
+    d = bids.internal.file_utils(d,'cpath');
 end
 dirmode = false;
 if nargin < 3

--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -1,6 +1,6 @@
 function meta = get_metadata(filename, pattern)
 % Read a BIDS's file metadata according to the inheritance principle
-% FORMAT meta = get_metadata(filename, pattern)
+% FORMAT meta = bids.internal.get_metadata(filename, pattern)
 % filename    - name of file following BIDS standard
 % pattern     - regular expression matching metadata file
 % meta        - metadata structure
@@ -13,7 +13,7 @@ function meta = get_metadata(filename, pattern)
 if nargin == 1, pattern = '^.*%s\\.json$'; end
 
 pth = fileparts(filename);
-p = parse_filename(filename);
+p = bids.internal.parse_filename(filename);
 
 meta = struct();
 
@@ -30,7 +30,7 @@ for n=1:N
     
     %-List the potential metadata files associated with this file suffix type
     % Default is to assume it is a JSON file
-    metafile = file_utils('FPList', pth, sprintf(pattern, p.type));
+    metafile = bids.internal.file_utils('FPList', pth, sprintf(pattern, p.type));
     
     if isempty(metafile), metafile = {}; else metafile = cellstr(metafile); end
     
@@ -38,7 +38,7 @@ for n=1:N
     % the file of interest
     for i=1:numel(metafile)
         
-        p2 = parse_filename(metafile{i});
+        p2 = bids.internal.parse_filename(metafile{i});
         fn = setdiff(fieldnames(p2),{'filename','ext','type'});
         
         %-Check if this metadata file contains the same entity-label pairs as its

--- a/+bids/+internal/parse_filename.m
+++ b/+bids/+internal/parse_filename.m
@@ -1,11 +1,11 @@
 function p = parse_filename(filename,fields)
 % Split a filename into its building constituents
-% FORMAT p = parse_filename(filename,fields)
+% FORMAT p = bids.internal.parse_filename(filename,fields)
 %
 % Example:
 %
 % >> filename = '../sub-16/anat/sub-16_ses-mri_run-1_echo-2_FLASH.nii.gz';
-% >> parse_filename(filename)
+% >> bids.internal.parse_filename(filename)
 %
 % ans = 
 %
@@ -23,7 +23,7 @@ function p = parse_filename(filename,fields)
 % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
-filename = file_utils(filename,'filename');
+filename = bids.internal.file_utils(filename,'filename');
 
 %-Identify all the BIDS entity-label pairs present in the filename (delimited by "_")
 % https://bids-specification.readthedocs.io/en/stable/99-appendices/04-entity-table.html

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -598,7 +598,7 @@ function subject = parse_dwi(subject)
             % -bval file
             % ------------------------------------------------------------------
             % bval file can also be stored at higher levels (inheritance principle)
-            bvalfile = get_metadata(fileList{i}, '^.*%s\\.bval$');
+            bvalfile = bids.internal.get_metadata(fileList{i}, '^.*%s\\.bval$');
             if isfield(bvalfile, 'filename')
                 subject.dwi(end).bval = bids.util.tsvread(bvalfile.filename); % ?
             end
@@ -606,7 +606,7 @@ function subject = parse_dwi(subject)
             % -bvec file
             % ------------------------------------------------------------------
             % bvec file can also be stored at higher levels (inheritance principle)
-            bvecfile = get_metadata(fileList{i}, '^.*%s\\.bvec$');
+            bvecfile = bids.internal.get_metadata(fileList{i}, '^.*%s\\.bvec$');
             if isfield(bvalfile, 'filename')
                 subject.dwi(end).bvec = bids.util.tsvread(bvecfile.filename); % ?
             end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -23,7 +23,7 @@ function BIDS = layout(root,tolerant)
         root = pwd;
     elseif nargin == 1
         if ischar(root)
-            root = file_utils(root, 'CPath');
+            root = bids.internal.file_utils(root, 'CPath');
         elseif isstruct(root)
             BIDS = root; % or BIDS = bids.layout(root.root);
             return;
@@ -104,7 +104,7 @@ function BIDS = layout(root,tolerant)
     
     %-Participant key file
     %==========================================================================
-    p = file_utils('FPList',BIDS.dir,'^participants\.tsv$');
+    p = bids.internal.file_utils('FPList',BIDS.dir,'^participants\.tsv$');
     if ~isempty(p)
         try
             BIDS.participants = bids.util.tsvread(p);
@@ -113,7 +113,7 @@ function BIDS = layout(root,tolerant)
             tolerant_message(tolerant, msg);
         end
     end
-    p = file_utils('FPList',BIDS.dir,'^participants\.json$');
+    p = bids.internal.file_utils('FPList',BIDS.dir,'^participants\.json$');
     if ~isempty(p)
         BIDS.participants.meta = bids.util.jsondecode(p);
     end
@@ -126,18 +126,18 @@ function BIDS = layout(root,tolerant)
     
     % -Tasks: JSON files are accessed through metadata
     % ==========================================================================
-    % t = file_utils('FPList',BIDS.dir,...
+    % t = bids.internal.file_utils('FPList',BIDS.dir,...
     %    '^task-.*_(beh|bold|events|channels|physio|stim|meg)\.(json|tsv)$');
     
     % -Subjects
     % ==========================================================================
-    sub = cellstr(file_utils('List', BIDS.dir, 'dir', '^sub-.*$'));
+    sub = cellstr(bids.internal.file_utils('List', BIDS.dir, 'dir', '^sub-.*$'));
     if isequal(sub, {''})
         error('No subjects found in BIDS directory.');
     end
     
     for iSub = 1:numel(sub)
-        sess = cellstr(file_utils('List', fullfile(BIDS.dir, sub{iSub}), 'dir', '^ses-.*$'));
+        sess = cellstr(bids.internal.file_utils('List', fullfile(BIDS.dir, sub{iSub}), 'dir', '^ses-.*$'));
         for iSess = 1:numel(sess)
             if isempty(BIDS.subjects)
                 BIDS.subjects = parse_subject(BIDS.dir, sub{iSub}, sess{iSess});
@@ -205,14 +205,14 @@ function subject = parse_anat(subject)
     % --------------------------------------------------------------------------
     pth = fullfile(subject.path, 'anat');
     if exist(pth, 'dir')
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_([a-zA-Z0-9]+){1}\\.nii(\\.gz)?$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
             % -Anatomy imaging data file
             % ------------------------------------------------------------------
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'acq', 'ce', 'rec', 'fa', 'echo', 'inv', 'run'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'acq', 'ce', 'rec', 'fa', 'echo', 'inv', 'run'});
             subject.anat = [subject.anat p];
             
         end
@@ -230,12 +230,12 @@ function subject = parse_func(subject)
         
         % -Task imaging data file
         % ----------------------------------------------------------------------
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_bold\\.nii(\\.gz)?$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
             subject.func = [subject.func p];
             subject.func(end).meta = struct([]); % ?
             
@@ -244,12 +244,12 @@ function subject = parse_func(subject)
         % -Task events file
         % ----------------------------------------------------------------------
         % (!) TODO: events file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_events\\.tsv$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
             subject.func = [subject.func p];
             subject.func(end).meta = bids.util.tsvread(fullfile(pth, fileList{i})); % ?
             
@@ -258,13 +258,13 @@ function subject = parse_func(subject)
         % -Physiological and other continuous recordings file
         % ----------------------------------------------------------------------
         % (!) TODO: stim file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_(physio|stim)\\.tsv\\.gz$', subject.name));
         % see also [_recording-<label>]
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'fa', 'echo', 'inv', 'run', 'recording', 'meta'});
             subject.func = [subject.func p];
             subject.func(end).meta = struct([]); % ?
             
@@ -279,7 +279,7 @@ function subject = parse_fmap(subject)
     % --------------------------------------------------------------------------
     pth = fullfile(subject.path, 'fmap');
     if exist(pth, 'dir')
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*\\.nii(\\.gz)?$', subject.name));
         fileList = convert_to_cell(fileList);
         j = 1;
@@ -295,8 +295,8 @@ function subject = parse_fmap(subject)
         if any(~cellfun(@isempty, labels))
             idx = find(~cellfun(@isempty, labels));
             for i = 1:numel(idx)
-                fb = file_utils(file_utils(fileList{idx(i)}, 'basename'), 'basename');
-                metafile = fullfile(pth, file_utils(fb, 'ext', 'json'));
+                fb = bids.internal.file_utils(bids.internal.file_utils(fileList{idx(i)}, 'basename'), 'basename');
+                metafile = fullfile(pth, bids.internal.file_utils(fb, 'ext', 'json'));
                 subject.fmap(j).type = 'phasediff';
                 subject.fmap(j).filename = fileList{idx(i)};
                 subject.fmap(j).magnitude = { ...
@@ -326,8 +326,8 @@ function subject = parse_fmap(subject)
         if any(~cellfun(@isempty, labels))
             idx = find(~cellfun(@isempty, labels));
             for i = 1:numel(idx)
-                fb = file_utils(file_utils(fileList{idx(i)}, 'basename'), 'basename');
-                metafile = fullfile(pth, file_utils(fb, 'ext', 'json'));
+                fb = bids.internal.file_utils(bids.internal.file_utils(fileList{idx(i)}, 'basename'), 'basename');
+                metafile = fullfile(pth, bids.internal.file_utils(fb, 'ext', 'json'));
                 subject.fmap(j).type = 'phase12';
                 subject.fmap(j).filename = { ...
                     fileList{idx(i)}, ...
@@ -361,8 +361,8 @@ function subject = parse_fmap(subject)
         if any(~cellfun(@isempty, labels))
             idx = find(~cellfun(@isempty, labels));
             for i = 1:numel(idx)
-                fb = file_utils(file_utils(fileList{idx(i)}, 'basename'), 'basename');
-                metafile = fullfile(pth, file_utils(fb, 'ext', 'json'));
+                fb = bids.internal.file_utils(bids.internal.file_utils(fileList{idx(i)}, 'basename'), 'basename');
+                metafile = fullfile(pth, bids.internal.file_utils(fb, 'ext', 'json'));
                 subject.fmap(j).type = 'fieldmap';
                 subject.fmap(j).filename = fileList{idx(i)};
                 subject.fmap(j).magnitude = strrep(fileList{idx(i)}, '_fieldmap.nii', '_magnitude.nii');
@@ -391,8 +391,8 @@ function subject = parse_fmap(subject)
         if any(~cellfun(@isempty, labels))
             idx = find(~cellfun(@isempty, labels));
             for i = 1:numel(idx)
-                fb = file_utils(file_utils(fileList{idx(i)}, 'basename'), 'basename');
-                metafile = fullfile(pth, file_utils(fb, 'ext', 'json'));
+                fb = bids.internal.file_utils(bids.internal.file_utils(fileList{idx(i)}, 'basename'), 'basename');
+                metafile = fullfile(pth, bids.internal.file_utils(fb, 'ext', 'json'));
                 subject.fmap(j).type = 'epi';
                 subject.fmap(j).filename = fileList{idx(i)};
                 subject.fmap(j).ses = regexprep(labels{idx(i)}.ses, '^_[a-zA-Z0-9]+-', '');
@@ -421,7 +421,7 @@ function subject = parse_eeg(subject)
         
         % -EEG data file
         % ----------------------------------------------------------------------
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_eeg\\..*[^json]$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
@@ -431,7 +431,7 @@ function subject = parse_eeg(subject)
             % The format used by the MATLAB toolbox EEGLAB (.set and .fdt files)
             % Biosemi data format (.bdf)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
             switch p.ext
                 case {'.edf', '.vhdr', '.set', '.bdf'}
                     % each recording is described with a single file, even though the data can consist of multiple
@@ -448,12 +448,12 @@ function subject = parse_eeg(subject)
         % -EEG events file
         % ----------------------------------------------------------------------
         % (!) TODO: events file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_events\\.tsv$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
             subject.eeg = [subject.eeg p];
             subject.eeg(end).meta = bids.util.tsvread(fullfile(pth, fileList{i})); % ?
             
@@ -462,12 +462,12 @@ function subject = parse_eeg(subject)
         % -Channel description table
         % ----------------------------------------------------------------------
         % (!) TODO: events file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_channels\\.tsv$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
             subject.eeg = [subject.eeg p];
             subject.eeg(end).meta = bids.util.tsvread(fullfile(pth, fileList{i})); % ?
             
@@ -475,12 +475,12 @@ function subject = parse_eeg(subject)
         
         % -Session-specific file
         % ----------------------------------------------------------------------
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s(_ses-[a-zA-Z0-9]+)?.*_(electrodes\\.tsv|photo\\.jpg|coordsystem\\.json|headshape\\..*)$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
             subject.eeg = [subject.eeg p];
             subject.eeg(end).meta = struct([]); % ?
             
@@ -499,7 +499,7 @@ function subject = parse_meg(subject)
         
         % -MEG data file
         % ----------------------------------------------------------------------
-        [fileList, d] = file_utils('List', pth, ...
+        [fileList, d] = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_meg\\..*[^json]$', subject.name));
         if isempty(fileList)
             fileList = d;
@@ -507,7 +507,7 @@ function subject = parse_meg(subject)
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
             subject.meg = [subject.meg p];
             subject.meg(end).meta = struct([]); % ?
             
@@ -516,12 +516,12 @@ function subject = parse_meg(subject)
         % -MEG events file
         % ----------------------------------------------------------------------
         % (!) TODO: events file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_events\\.tsv$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
             subject.meg = [subject.meg p];
             subject.meg(end).meta = bids.util.tsvread(fullfile(pth, fileList{i})); % ?
             
@@ -530,12 +530,12 @@ function subject = parse_meg(subject)
         % -Channels description table
         % ----------------------------------------------------------------------
         % (!) TODO: channels file can also be stored at higher levels (inheritance principle)
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_channels\\.tsv$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
             subject.meg = [subject.meg p];
             subject.meg(end).meta = bids.util.tsvread(fullfile(pth, fileList{i})); % ?
             
@@ -543,12 +543,12 @@ function subject = parse_meg(subject)
         
         % -Session-specific file
         % ----------------------------------------------------------------------
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s(_ses-[a-zA-Z0-9]+)?.*_(photo\\.jpg|coordsystem\\.json|headshape\\..*)$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'});
             subject.meg = [subject.meg p];
             subject.meg(end).meta = struct([]); % ?
             
@@ -564,7 +564,7 @@ function subject = parse_beh(subject)
     % --------------------------------------------------------------------------
     pth = fullfile(subject.path, 'beh');
     if exist(pth, 'dir')
-        fileList = file_utils('FPList', pth, ...
+        fileList = bids.internal.file_utils('FPList', pth, ...
             sprintf('^%s.*_(events\\.tsv|beh\\.json|physio\\.tsv\\.gz|stim\\.tsv\\.gz)$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
@@ -572,7 +572,7 @@ function subject = parse_beh(subject)
             % -Event timing, metadata, physiological and other continuous
             % recordings
             % ------------------------------------------------------------------
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task'});
             subject.beh = [subject.beh p];
             
         end
@@ -585,14 +585,14 @@ function subject = parse_dwi(subject)
     % --------------------------------------------------------------------------
     pth = fullfile(subject.path, 'dwi');
     if exist(pth, 'dir')
-        fileList = file_utils('FPList', pth, ...
+        fileList = bids.internal.file_utils('FPList', pth, ...
             sprintf('^%s.*_([a-zA-Z0-9]+){1}\\.nii(\\.gz)?$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
             % -Diffusion imaging file
             % ------------------------------------------------------------------
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'acq', 'run', 'bval', 'bvec'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'acq', 'run', 'bval', 'bvec'});
             subject.dwi = [subject.dwi p];
             
             % -bval file
@@ -621,14 +621,14 @@ function subject = parse_pet(subject)
     % --------------------------------------------------------------------------
     pth = fullfile(subject.path, 'pet');
     if exist(pth, 'dir')
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_pet\\.nii(\\.gz)?$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
             
             % -PET imaging file
             % ------------------------------------------------------------------
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'run'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'rec', 'run'});
             subject.pet = [subject.pet p];
             
         end
@@ -644,7 +644,7 @@ function subject = parse_ieeg(subject)
         
         % -iEEG data file
         % ----------------------------------------------------------------------
-        fileList = file_utils('List', pth, ...
+        fileList = bids.internal.file_utils('List', pth, ...
             sprintf('^%s.*_task-.*_ieeg\\..*[^json]$', subject.name));
         fileList = convert_to_cell(fileList);
         for i = 1:numel(fileList)
@@ -655,7 +655,7 @@ function subject = parse_ieeg(subject)
             % Neurodata Without Borders (.nwb)
             % MEF3 (.mef)
             
-            p = parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
+            p = bids.internal.parse_filename(fileList{i}, {'sub', 'ses', 'task', 'acq', 'run', 'meta'});
             switch p.ext
                 case {'.edf', '.vhdr', '.set', '.nwb', '.mef'}
                     % each recording is described with a single file, even though the data can consist of multiple

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -99,7 +99,7 @@ switch query
                         case 'metadata'
                             if sts && isfield(d(k),'filename')
                                 f = fullfile(BIDS.subjects(i).path,mods{j},d(k).filename);
-                                result{end+1} = get_metadata(f);
+                                result{end+1} = bids.internal.get_metadata(f);
                                 if ~isempty(target)
                                     try
                                         result{end} = subsref(result{end},target);

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ install:
   - octave $OCTFLAGS --eval "addpath (fullfile (pwd, 'JSONio')); savepath ();"
   # Install BIDS-MATLAB
   - octave $OCTFLAGS --eval "addpath (pwd); savepath ();"
-  # Temporary fix for private directories in packages in Octave
-  - octave $OCTFLAGS --eval "addpath (fullfile (pwd, '+bids')); savepath ();"
   # Install BIDS-Validator
   - sudo npm install -g bids-validator
 


### PR DESCRIPTION
What do you think of moving the package-private functions in `+bids/private` to a new `+bids/+internal` package?

This would allow these functions to be directly tested and played with during development, but would still indicate to users of the library that they're for BIDS-MATLAB's internal use and shouldn't be called from client code. This "internal" package name is a pretty well-established convention these days. I've seen it in both Java and Matlab code, including MathWorks' own code.

This also removes the need to do the extra `addpath` step under Octave to work around its handling of `private` directories inside packages. This PR updates the `.travis.yml` file to reflect that.