### PR TITLE
Fix or suppress M-lint code inspection warnings

### DIFF
--- a/+bids/+util/tsvread.m
+++ b/+bids/+util/tsvread.m
@@ -130,7 +130,7 @@ n2  = cellfun(@(x) strcmpi(x,'NaN'),var);
 if header && any(n1 & ~n2)
     hdr     = true;
     try
-        var = genvarname(var);
+        var = genvarname(var); %#ok<DEPGENAM>
     catch
         var = matlab.lang.makeValidName(var,'ReplacementStyle','hex');
         var = matlab.lang.makeUniqueStrings(var);

--- a/+bids/private/file_utils.m
+++ b/+bids/private/file_utils.m
@@ -17,6 +17,7 @@ function varargout = file_utils(str,varargin)
 
 % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 
+%#ok<*AGROW>
 
 if ismember(lower(str), {'list','fplist'})
     [varargout{1:nargout}] = listfiles(str, varargin{:});

--- a/+bids/private/parse_filename.m
+++ b/+bids/private/parse_filename.m
@@ -27,7 +27,7 @@ filename = file_utils(filename,'filename');
 
 %-Identify all the BIDS entitiy-label pairs present in the filename (delimited by "_")
 % https://bids-specification.readthedocs.io/en/stable/99-appendices/04-entity-table.html
-[parts, dummy] = regexp(filename,'(?:_)+','split','match');
+[parts, dummy] = regexp(filename,'(?:_)+','split','match'); %#ok<ASGLU>
 p.filename = filename;
 
 %-Identify the suffix and extension of this file
@@ -36,7 +36,7 @@ p.filename = filename;
 
 %-Separate the entity from the label for each pair identified above
 for i=1:numel(parts)-1
-    [d, dummy] = regexp(parts{i},'(?:\-)+','split','match');
+    [d, dummy] = regexp(parts{i},'(?:\-)+','split','match'); %#ok<ASGLU>
     p.(d{1}) = d{2};
 end
 

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -16,6 +16,7 @@ function result = query(BIDS,query,varargin)
 % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
+%#ok<*AGROW>
 
 if nargin < 2
     error('Not enough input arguments.');

--- a/+bids/report.m
+++ b/+bids/report.m
@@ -398,7 +398,7 @@ function ST_def = define_slice_timing(SliceTiming)
 if iscell(SliceTiming)
     SliceTiming = cell2mat(SliceTiming);
 end
-[dummy,I] = sort(SliceTiming);
+[~,I] = sort(SliceTiming);
 if all(I==(1:numel(I))')
     ST_def = 'ascending';
 elseif all(I==(numel(I):-1:1)')

--- a/+bids/validate.m
+++ b/+bids/validate.m
@@ -17,7 +17,7 @@ function [sts, msg] = validate(root)
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
 
-[sts, msg] = system('bids-validator --version');
+[sts, ~] = system('bids-validator --version');
 if sts
     msg = 'Require bids-validator from https://github.com/bids-standard/bids-validator';
 else


### PR DESCRIPTION
Just a couple M-lint warning fixes. With this PR merged, bids-matlab will be M-lint clean. (In Matlab R2014b, anyway. In R2019b, there are some new M-lint warnings that pop up. But you can't be clean in both versions: if you suppress the new R2019b warnings, then R2014b will give you warnings about spurious inspection suppressions. You can't win. ;) )