### PR TITLE
Include QUERY in the H1 line for query's helptext

### DIFF
--- a/+bids/query.m
+++ b/+bids/query.m
@@ -1,5 +1,5 @@
 function result = query(BIDS,query,varargin)
-% Query a directory structure formated according to the BIDS standard
+% QUERY Query a directory structure formatted according to the BIDS standard
 % FORMAT result = bids.query(BIDS,query,...)
 % BIDS   - BIDS directory name or BIDS structure (from bids.layout)
 % query  - type of query: {'data', 'metadata', 'sessions', 'subjects',


### PR DESCRIPTION
Due to a quirk of how Matlab parses H1 lines in helptext, the word "Query" in the H1 line of query is being dropped in some contexts, like when you do `help bids` to see the contents listing of the `bids` package. This is because if the first word of the H1 line is the same name as the function, it's treated as the function name leading the H1 line, and not the first word of the function description. Here, it's meant to be the first word of the function description, acting as the function verb.

Before (in Matlab R2019b):

```
>> help bids
Contents of bids package:

  layout - Parse a directory structure formated according to the bids standard
   query - a directory structure formated according to the bids standard
```

This PR adds a second "QUERY" to the H1 line, so the second "Query" always gets preserved as part of the intro sentence.

After:
```
>> help bids
Contents of bids package:

  layout - Parse a directory structure formated according to the bids standard
   query - Query a directory structure formatted according to the bids standard
```
