### PR TITLE
More detailed error messages

### DIFF
--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -26,10 +26,9 @@ elseif nargin == 1
         BIDS = root; % or BIDS = bids.layout(root.root);
         return;
     else
-        error('Invalid syntax.');
+        error('Invalid input: root must be a char filename or a BIDS struct; got a %s',...
+            class(root));
     end
-else
-    error('Too many input arguments.');
 end
 
 %-BIDS structure
@@ -47,21 +46,26 @@ BIDS = struct(...
 %-Validation of BIDS root directory
 %==========================================================================
 if ~exist(BIDS.dir,'dir')
-    error('BIDS directory does not exist.');
+    error('BIDS directory does not exist: ''%s''',BIDS.dir);
 elseif ~exist(fullfile(BIDS.dir,'dataset_description.json'),'file')
-    error('BIDS directory not valid: missing dataset_description.json.');
+    error('BIDS directory not valid: missing dataset_description.json: ''%s''',...
+        BIDS.dir);
 end
 
 %-Dataset description
 %==========================================================================
 try
     BIDS.description = bids.util.jsondecode(fullfile(BIDS.dir,'dataset_description.json'));
-catch
-    error('BIDS dataset description could not be read.');
+catch err
+    error('BIDS dataset description could not be read: %s',err.message);
 end
-if ~isfield(BIDS.description,'BIDSVersion') || ~isfield(BIDS.description,'Name')
-    error('BIDS dataset description not valid.');
+if ~isfield(BIDS.description,'BIDSVersion')
+    error('BIDS dataset description not valid: missing BIDSVersion field');
 end
+if ~isfield(BIDS.description,'Name')
+    error('BIDS dataset description not valid: missing Name field');
+end
+
 % See also optional README and CHANGES files
 
 %-Optional directories

--- a/+bids/private/file_utils.m
+++ b/+bids/private/file_utils.m
@@ -47,7 +47,7 @@ if numel(options) == 1
             case 'fpath'
                 str{n} = fileparts(char(cpath(str(n))));
             otherwise
-                error('Unknown option.');
+                error('Unknown option: ''%s''',options{1});
         end
     end
     options = {};
@@ -186,7 +186,7 @@ switch lower(action)
     case 'fplist'
         fp = true;
     otherwise
-        error('Invalid syntax.');
+        error('Invalid action: ''%s''.',action);
 end
 if nargin < 2
     d = pwd;

--- a/+bids/private/parse_filename.m
+++ b/+bids/private/parse_filename.m
@@ -50,7 +50,7 @@ if nargin == 2
     try
         p = orderfields(p,['filename','ext','type',fields]);
     catch
-        warning('Ignoring file "%s" not matching template.',filename);
+        warning('Ignoring file ''%s'' not matching template.',filename);
         p = struct([]);
     end
 end

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -16,10 +16,7 @@ function result = query(BIDS,query,varargin)
 % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers
 
-
-if nargin < 2
-    error('Not enough input arguments.');
-end
+narginchk(2,Inf);
 
 BIDS = bids.layout(BIDS);
 
@@ -147,7 +144,7 @@ switch query
                 result(cellfun('isempty',result)) = [];
         end
     otherwise
-        error('Unable to perform BIDS query.');
+        error('Invalid query input: ''%s''', query);
 end
 
 

--- a/tests/bids_runtests.m
+++ b/tests/bids_runtests.m
@@ -38,9 +38,8 @@ for i=1:numel(d)
         fprintf('%s',d(i).name(1:end-2));
         feval(d(i).name(1:end-2));
         results(i).Passed = true;
-    catch
+    catch err
         results(i).Failed = true;
-        err = lasterror;
         fprintf('\n%s',err.message);
     end
     

--- a/tests/test_bids_examples.m
+++ b/tests/test_bids_examples.m
@@ -30,10 +30,9 @@ for i=1:numel(d)
         BIDS = bids.layout(fullfile(pth,d(i).name));
         sts(i) = true;
         fprintf('.');
-    catch
+    catch err
         fprintf('X');
-        le = lasterror;
-        msg{i} = le.message;
+        msg{i} = err.message;
     end
 end
 fprintf('\n');


### PR DESCRIPTION
Here's a suggestion for more detailed error messages. This mostly involves including the actual problematic values in error messages, including a specific reason/underlying error message for a failure, or telling which BIDS file/dir it was trying to process when the error occurred. This will make it easier for users to diagnose errors when using BIDS-MATLAB.

It also switches to using the `catch <err>` syntax where appropriate. This syntax is supported by all Matlab and Octave versions indicated in https://github.com/bids-standard/bids-matlab/issues/22, and is more concise than calling `lasterror()`.