### PR TITLE
gitignore: ignore local copy of bids-examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.asv
 *.*~
+/tests/bids-examples


### PR DESCRIPTION
In the context of the CI runs, the bids-examples repo is downloaded and installed into `tests/`. It might be nice to support this workflow in local interactive usage, too. Adding it to the gitignore lets developers drop `bids-examples` in the same place as the test code is expecting it, without accidentally checking it into git on the main repo.