### PR TITLE
Make function helptext more concise with a +bids/Contents.m

### DIFF
--- a/+bids/+util/tsvread.m
+++ b/+bids/+util/tsvread.m
@@ -1,5 +1,5 @@
 function x = tsvread(f,v,hdr)
-% Load text and numeric data from file
+% Load text and numeric data from tab-separated-value or other file
 % FORMAT x = tsvread(f,v,hdr)
 % f   - filename (can be gzipped) {txt,mat,csv,tsv,json}
 % v   - name of field to return if data stored in a structure [default: '']
@@ -7,6 +7,7 @@ function x = tsvread(f,v,hdr)
 % hdr - detect the presence of a header row for csv/tsv [default: true]
 %
 % x   - corresponding data array or structure
+
 %__________________________________________________________________________
 %
 % Based on spm_load.m from SPM12.

--- a/+bids/Contents.m
+++ b/+bids/Contents.m
@@ -1,0 +1,22 @@
+% +BIDS - The bids-matlab library
+%
+% Contents
+%   layout   - Parse a directory structure formated according to the BIDS standard
+%   query    - Query a directory structure formated according to the BIDS standard
+%   report   - Create a short summary of the acquisition parameters of a BIDS dataset
+%   validate - BIDS Validator
+%   util.jsondecode - Decode JSON-formatted file
+%   util.jsonencode - Encode JSON-formatted file
+%   util.tsvread - Load text and numeric data from tab-separated-value or other file
+%
+%__________________________________________________________________________
+%
+% BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
+%   The brain imaging data structure, a format for organizing and
+%   describing outputs of neuroimaging experiments.
+%   K. J. Gorgolewski et al, Scientific Data, 2016.
+%__________________________________________________________________________
+%
+% BIDS-MATLAB is a library that aims at centralising MATLAB/Octave tools
+% for interacting with datasets conforming to the BIDS format.
+% See https://github.com/bids-standard/bids-matlab for more details.

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -3,6 +3,10 @@ function BIDS = layout(root)
 % FORMAT BIDS = bids.layout(root)
 % root   - directory formated according to BIDS [Default: pwd]
 % BIDS   - structure containing the BIDS file layout
+%
+% See also:
+% bids
+
 %__________________________________________________________________________
 %
 % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -5,6 +5,10 @@ function result = query(BIDS,query,varargin)
 % query  - type of query: {'data', 'metadata', 'sessions', 'subjects',
 %          'runs', 'tasks', 'runs', 'types', 'modalities'}
 % result - outcome of query
+%
+% See also:
+% bids
+
 %__________________________________________________________________________
 %
 % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/

--- a/+bids/report.m
+++ b/+bids/report.m
@@ -16,6 +16,10 @@ function report(BIDS, Subj, Ses, Run, ReadNII)
 % Unless specified the function will only read the data from the first
 % subject, session, and run (for each task of BOLD). This can be an issue
 % if different subjects/sessions contain very different data.
+%
+% See also:
+% bids
+
 %__________________________________________________________________________
 %
 % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/

--- a/+bids/validate.m
+++ b/+bids/validate.m
@@ -12,6 +12,9 @@ function [sts, msg] = validate(root)
 % Web version: 
 %   https://bids-standard.github.io/bids-validator/
 %__________________________________________________________________________
+%
+% See also:
+% bids
 
 % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
 % Copyright (C) 2018--, BIDS-MATLAB developers


### PR DESCRIPTION
What do you think about making the per-function helptext more concise by concentrating the whole-library doco in a central `+bids/Contents.m` help file (that pops up when you do `help bids`)?

This way users can do `help bids` to get info on the overall library, and `help <fcn>` for the individual functions takes up less precious space in the command window. Each of the individual function help texts will have a link to the main `bids` help item so it'll be easy for users to find.

Works in Matlab R2014b-R2019b, though there's a bug in earlier versions of Matlab that causes the help for `help bids` to be displayed twice.