### PR TITLE
[INFRA] Customize code suggestions & completions by adding a functionSignatures file

### DIFF
--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -1,0 +1,24 @@
+{
+    "bids.layout":
+    {
+	"inputs":
+	[
+	    {"name":"root", "kind":"required", "type":"folder"}
+	]
+    },
+    "bids.query":
+    {
+	"inputs":
+	[
+	    {"name":"BIDS", "kind":"required", "type":"struct"},
+	    {"name":"query", "kind":"required", "type":["char", "string", "choices={'data','metadata','sessions','subjects','runs','tasks','types','modalities'}"]}
+	]
+    },
+    "bids.validate":
+    {
+	"inputs":
+	[
+	    {"name":"root", "kind":"required", "type":"folder"}
+	]
+    }
+}

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -11,7 +11,7 @@
 	"inputs":
 	[
 	    {"name":"BIDS", "kind":"required", "type":"struct"},
-	    {"name":"query", "kind":"required", "type":["char", "string", "choices={'data','metadata','sessions','subjects','runs','tasks','types','modalities'}"]}
+	    {"name":"query", "kind":"required", "type":["char", "choices={'data','metadata','sessions','subjects','runs','tasks','types','modalities'}"]}
 	]
     },
     "bids.validate":

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -20,5 +20,16 @@
 	[
 	    {"name":"root", "kind":"required", "type":"folder"}
 	]
+    },
+    "bids.report":
+    {
+	"inputs":
+	[
+	    {"name":"BIDS", "kind":"ordered", "type":[["folder"],["struct"]]},
+	    {"name":"Subj", "kind":"ordered", "type":"numeric"},
+	    {"name":"Ses", "kind":"ordered", "type":"numeric"},
+	    {"name":"Run", "kind":"ordered", "type":"numeric"},
+	    {"name":"ReadNII", "kind":"ordered", "type":"boolean"}
+	]
     }
 }

--- a/functionSignatures.json
+++ b/functionSignatures.json
@@ -38,7 +38,7 @@
 		"inputs": [
 			{
 				"name": "BIDS",
-				"kind": "ordered",
+				"kind": "positional",
 				"type": [
 					[
 						"folder"
@@ -50,22 +50,22 @@
 			},
 			{
 				"name": "Subj",
-				"kind": "ordered",
+				"kind": "positional",
 				"type": "numeric"
 			},
 			{
 				"name": "Ses",
-				"kind": "ordered",
+				"kind": "positional",
 				"type": "numeric"
 			},
 			{
 				"name": "Run",
-				"kind": "ordered",
+				"kind": "positional",
 				"type": "numeric"
 			},
 			{
 				"name": "ReadNII",
-				"kind": "ordered",
+				"kind": "positional",
 				"type": "boolean"
 			}
 		]

--- a/tests/test_functionSignatures.m
+++ b/tests/test_functionSignatures.m
@@ -1,0 +1,24 @@
+function test_functionSignatures(pth)
+% Test functionSignatures.json file
+% The functionSignatures file is used by Matlab to provide code suggestions
+% and completions for functions.
+%
+%__________________________________________________________________________
+%
+% BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
+%   The brain imaging data structure, a format for organizing and
+%   describing outputs of neuroimaging experiments.
+%   K. J. Gorgolewski et al, Scientific Data, 2016.
+%__________________________________________________________________________
+%
+% Copyright (C) 2020--, BIDS-MATLAB developers
+
+if ~nargin
+    % parent directory of the tests directory
+    pth = fullfile(pwd, '..');
+end
+
+% Run a smoke test - see if the file is a readable json
+signatures = bids.util.jsondecode(...
+    fullfile(pth, 'functionSignatures.json'));
+assert(isstruct(signatures))


### PR DESCRIPTION
I would like to propose a minor Quality of Life improvement (at least for Matlab users - I don't think Octave uses the same mechanism) by providing hints for tab-autocompletion. This can be done by adding a functionSignatures file ([docs](https://www.mathworks.com/help/matlab/matlab_prog/customize-code-suggestions-and-completions.html)), which affects the behavior of Matlab's Command Window, Editor and Live Editor.

The file included in the pull request causes Matlab to:
* autocomplete paths in calls to bids.layout, bids.query and bids.validate
* suggest a choice of 'data', 'metadata', 'sessions' etc. as a second argument to bids.query (typing `bids.query(BIDS, <tab>)` shows the suggestions)

I am not sure if you will consider having autocompletion hints a useful feature, so the provided annotations are rather minimal (i.e just a few arguments, and none for bids.report), although that is already quite handy for my own use.

Possible additions could include eg. adding all possible keys for key-value pairs in bids.query (although - is there a limited set?) and annotating bids.report. I would be happy to do more work if you think an expansion would be needed.