### PR TITLE
[FIX] Filter subjects and sessions when querying modalities (issue #65)

### DIFF
--- a/+bids/query.m
+++ b/+bids/query.m
@@ -143,7 +143,7 @@ switch query
                 result = unique(result);
                 result = regexprep(result,'^[a-zA-Z0-9]+-','');
                 result(cellfun('isempty',result)) = [];
-            case 'data'
+            case {'modalities','data'}
                 result = result';
             case 'metadata'
                 if numel(result) == 1

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -28,13 +28,7 @@ BIDS = bids.layout(BIDS);
 opts = parse_query(varargin);
 
 switch query
-    case 'modalities'
-        hasmod = arrayfun(@(y) structfun(@(x) isstruct(x) & ~isempty(x),y),...
-            BIDS.subjects,'UniformOutput',false);
-        hasmod = any([hasmod{:}],2);
-        mods   = fieldnames(BIDS.subjects)';
-        result = mods(hasmod);
-    case {'sessions', 'subjects', 'tasks', 'runs', 'types', 'data', 'metadata'}
+    case {'sessions', 'subjects', 'modalities', 'tasks', 'runs', 'types', 'data', 'metadata'}
         %-Initialise output variable
         result = {};
         
@@ -54,7 +48,11 @@ switch query
             mods = opts{ismember(opts(:,1),'modality'),2};
             opts(ismember(opts(:,1),'modality'),:) = [];
         else
-            mods = bids.query(BIDS,'modalities');
+            hasmod = arrayfun(@(y) structfun(@(x) isstruct(x) & ~isempty(x),y),...
+                        BIDS.subjects,'UniformOutput',false);
+            hasmod = any([hasmod{:}],2);
+            mods   = fieldnames(BIDS.subjects)';
+            mods   = mods(hasmod);
         end
         
         %-Get optional target option for metadata query
@@ -91,6 +89,13 @@ switch query
                         case 'sessions'
                             if sts
                                 result{end+1} = BIDS.subjects(i).session;
+                            end
+                        case 'modalities'
+                            if sts
+                                hasmod = structfun(@(x) isstruct(x) & ~isempty(x),...
+                                    BIDS.subjects(i));
+                                allmods = fieldnames(BIDS.subjects(i))';
+                                result = union(result, allmods(hasmod));
                             end
                         case 'data'
                             if sts && isfield(d(k),'filename')

--- a/tests/test_bids_query.m
+++ b/tests/test_bids_query.m
@@ -35,6 +35,7 @@ assert(isequal(bids.query(BIDS,'types'),types));
 
 mods = {'anat','func'};
 assert(isequal(bids.query(BIDS,'modalities'),mods));
+assert(isequal(bids.query(BIDS,'modalities','sub','01'),mods));
 
 assert(isempty(bids.query(BIDS,'runs','type','T1w')));
 
@@ -62,3 +63,14 @@ BIDS = bids.layout(pth);
 sessions = {'01','02'};
 assert(isequal(bids.query(BIDS,'sessions'),sessions))
 assert(isequal(bids.query(BIDS,'sessions','sub','02'),sessions))
+
+% Check modalities
+%   parse a folder with different modalities per session
+pth = fullfile(fileparts(pth),'7t_trt');
+BIDS = bids.layout(pth);
+%   test
+mods = {'anat','fmap','func'};
+assert(isequal(bids.query(BIDS,'modalities'),mods))
+assert(isequal(bids.query(BIDS,'modalities','sub','01'),mods))
+assert(isequal(bids.query(BIDS,'modalities','sub','01','ses','1'),mods))
+assert(isequal(bids.query(BIDS,'modalities','sub','01','ses','2'),mods(2:3)))


### PR DESCRIPTION
It might be time to remove the remaining `switch`/`case` as there are no special cases any more.