### PR TITLE
[INFRA] Use Ubuntu Focal 20.04 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI (https://travis-ci.org/)
 
 language: c
-dist: bionic
+dist: focal
 cache:
   apt: true # only works with Pro version
 


### PR DESCRIPTION
This will now use Octave 5.2.0 for tests.