### PR TITLE
miss_hit.cfg: define project_root

### DIFF
--- a/miss_hit.cfg
+++ b/miss_hit.cfg
@@ -1,5 +1,7 @@
 # style guide (https://florianschanda.github.io/miss_hit/style_checker.html)
 
+project_root
+
 # rules that we do not apply
 suppress_rule: "naming_functions"
 suppress_rule: "naming_classes"


### PR DESCRIPTION
The [MISS_HIT Configuration Guide](https://florianschanda.github.io/miss_hit/configuration.html) recommends putting a `project_root` in your top-level `miss_hit.cfg` file. This will make it play nicely if bids-matlab is included in some other project using MISS_HIT, and maybe optimize the `mh_*` programs' lookup of config files.