### PR TITLE
[ENH] add possibility to query for (and filter queries with) extensions

### DIFF
--- a/+bids/+internal/keep_file_for_query.m
+++ b/+bids/+internal/keep_file_for_query.m
@@ -1,10 +1,15 @@
-function status = keep_file(file_struct, options)
+function status = keep_file_for_query(file_struct, options)
 
   status = true;
 
-  % suffix is treated separately as it is not one of the entities
+  % suffix and extensions are treated separately
+  % as they are not one of the entities
   for l = 1:size(options, 1)
     if strcmp(options{l, 1}, 'suffix') && ~ismember(file_struct.suffix, options{l, 2})
+      status = false;
+      return
+    end
+    if strcmp(options{l, 1}, 'extension') && ~ismember(file_struct.ext, options{l, 2})
       status = false;
       return
     end
@@ -12,7 +17,7 @@ function status = keep_file(file_struct, options)
 
   for l = 1:size(options, 1)
 
-    if ~strcmp(options{l, 1}, 'suffix')
+    if ~any(strcmp(options{l, 1}, {'suffix', 'extension'}))
 
       if ~ismember(options{l, 1}, fieldnames(file_struct.entities))
         status = false;

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -44,7 +44,8 @@ function result = query(BIDS, query, varargin)
                    'suffixes', ...
                    'data', ...
                    'metadata', ...
-                   'dependencies'};
+                   'dependencies', ...
+                   'extensions'};
 
   if ~any(strcmp(query, VALID_QUERIES))
     error('Invalid query input: ''%s''', query);
@@ -86,7 +87,7 @@ function result = query(BIDS, query, varargin)
         result = result{1};
       end
 
-    case {'tasks', 'runs', 'suffixes'}
+    case {'tasks', 'runs', 'suffixes', 'extensions'}
       result = unique(result);
       result(cellfun('isempty', result)) = [];
   end
@@ -247,6 +248,11 @@ function result = perform_query(BIDS, query, options, subjects, modalities, targ
             case 'suffixes'
               if isfield(d(k), 'suffix')
                 result{end + 1} = d(k).suffix;
+              end
+
+            case 'extensions'
+              if isfield(d(k), 'ext')
+                result{end + 1} = d(k).ext;
               end
 
             case 'dependencies'

--- a/tests/test_bids_query.m
+++ b/tests/test_bids_query.m
@@ -23,6 +23,29 @@ function test_suite = test_bids_query %#ok<*STOUT>
 
 end
 
+function test_query_extension()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, 'ds007'));
+
+  extensions = bids.query(BIDS, 'extensions');
+
+  data = bids.query(BIDS, 'data', ...
+                    'sub', '01', ...
+                    'task', 'stopsignalwithpseudowordnaming', ...
+                    'extension', '.nii.gz', ...
+                    'suffix', 'bold');
+  assertEqual(size(data, 1), 2);
+
+  data = bids.query(BIDS, 'data', ...
+                    'sub', '01', ...
+                    'task', 'stopsignalwithpseudowordnaming', ...
+                    'extension', '.tsv');
+  assertEqual(size(data, 1), 2);
+
+end
+
 function test_query_data()
 
   pth_bids_example = get_test_data_dir();

--- a/tests/test_keep_file.m
+++ b/tests/test_keep_file.m
@@ -10,6 +10,7 @@ end
 function test_keep_file_basic()
 
   file_struct = struct('suffix', 'bold', ...
+                       'ext', '.nii.gz', ...
                        'entities', struct('task', 'balloon', ...
                                           'ses', '01', ...
                                           'sub', '02'));
@@ -28,6 +29,10 @@ function test_keep_file_basic()
 
   options = {'suffix', {'bold'}};
   assertEqual(bids.internal.keep_file_for_query(file_struct, options), true);
+
+  options = {'suffix', {'bold'}
+             'extension', {'.nii'}};
+  assertEqual(bids.internal.keep_file_for_query(file_struct, options), false);
 
   options = {'suffix', {'T1w', 'bold'}};
   assertEqual(bids.internal.keep_file_for_query(file_struct, options), true);


### PR DESCRIPTION
fix #141 

allows to return only zipped files or tables

```matlab
  pth_bids_example = get_test_data_dir();

  BIDS = bids.layout(fullfile(pth_bids_example, 'ds007'));

  extensions = bids.query(BIDS, 'extensions')

ans =

  1×2 cell array

    '.nii.gz'    '.tsv'


%%
  data = bids.query(BIDS, 'data', ...
                    'sub', '01', ...
                    'task', 'stopsignalwithpseudowordnaming', ...
                    'extension', '.nii.gz', ...
                    'suffix', 'bold')

ans =

  2×1 cell array

    'bids-examples/ds007/sub-01/func/sub-01_task-stopsignalwithpseudowordnaming_run-01_bold.nii.gz'
    'bids-examples/ds007/sub-01/func/sub-01_task-stopsignalwithpseudowordnaming_run-02_bold.nii.gz'


%%
  data = bids.query(BIDS, 'data', ...
                    'sub', '01', ...
                    'task', 'stopsignalwithpseudowordnaming', ...
                    'extension', '.tsv')

ans =

  2×1 cell array

    'bids-examples/ds007/sub-01/func/sub-01_task-stopsignalwithpseudowordnaming_run-01_events.tsv'
    'bids-examples/ds007/sub-01/func/sub-01_task-stopsignalwithpseudowordnaming_run-02_events.tsv'
```