### PR TITLE
[ENH] improve management of "intended_for"

### DIFF
--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -1,8 +1,17 @@
 function meta = get_metadata(filename, pattern)
+  %
   % Read a BIDS's file metadata according to the inheritance principle
-  % FORMAT meta = bids.internal.get_metadata(filename, pattern)
-  % filename    - name of file following BIDS standard
-  % pattern     - regular expression matching metadata file
+  %
+  % USAGE::
+  %
+  %    meta = bids.internal.get_metadata(filename, pattern)
+  %
+  % :param filename: name of file following BIDS standard
+  % :type  filename: string
+  % :param pattern:  regular expression matching metadata file
+  % :type  pattern:  string
+  %
+  %
   % meta        - metadata structure
   % __________________________________________________________________________
 

--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -4,11 +4,12 @@ function meta = get_metadata(filename, pattern)
   %
   % USAGE::
   %
-  %    meta = bids.internal.get_metadata(filename, pattern)
+  %    meta = bids.internal.get_metadata(filename, pattern = '^.*%s\\.json$')
   %
-  % :param filename: name of file following BIDS standard
+  % :param filename: fullpath name of file following BIDS standard
   % :type  filename: string
-  % :param pattern:  regular expression matching metadata file
+  % :param pattern:  Regular expression matching the metadata file (default is ``'^.*%s\\.json$'``)
+  %                  If provided, it must at least be ``'%s'``.
   % :type  pattern:  string
   %
   %

--- a/+bids/+internal/return_file_index.m
+++ b/+bids/+internal/return_file_index.m
@@ -1,4 +1,8 @@
 function file_idx = return_file_index(BIDS, modality, filename)
+  %
+  % For a given filename and modality, it returns the file index
+  % in the subject sub-structure of the BIDS structure
+  %
 
   % Copyright (C) 2018--, BIDS-MATLAB developers
 

--- a/+bids/+internal/return_file_index.m
+++ b/+bids/+internal/return_file_index.m
@@ -1,0 +1,10 @@
+function file_idx = return_file_index(BIDS, modality, filename)
+
+  % Copyright (C) 2018--, BIDS-MATLAB developers
+
+  sub_idx = bids.internal.return_subject_index(BIDS, filename);
+
+  file_idx = strcmp(filename, {BIDS.subjects(sub_idx).(modality).filename}');
+  file_idx = find(file_idx);
+
+end

--- a/+bids/+internal/return_file_info.m
+++ b/+bids/+internal/return_file_info.m
@@ -1,0 +1,12 @@
+function file_info = return_file_info(BIDS, fullpath_filename)
+
+  file_info.path = bids.internal.file_utils(fullpath_filename, 'path');
+  file_info.modality = bids.internal.file_utils(file_info.path, 'filename');
+  file_info.filename = bids.internal.file_utils(fullpath_filename, 'filename');
+
+  file_info.sub_idx = bids.internal.return_subject_index(BIDS, file_info.filename);
+  file_info.file_idx = bids.internal.return_file_index(BIDS, ...
+                                                       file_info.modality, ...
+                                                       file_info.filename);
+
+end

--- a/+bids/+internal/return_subject_index.m
+++ b/+bids/+internal/return_subject_index.m
@@ -1,4 +1,9 @@
 function sub_idx = return_subject_index(BIDS, filename)
+  %
+  % For a given filename, it returns the subject index in BIDS structure so
+  % that: ``BIDS.subjects(sub_idx)``
+  %
+  %
 
   % Copyright (C) 2018--, BIDS-MATLAB developers
 

--- a/+bids/+internal/return_subject_index.m
+++ b/+bids/+internal/return_subject_index.m
@@ -1,0 +1,18 @@
+function sub_idx = return_subject_index(BIDS, filename)
+
+  % Copyright (C) 2018--, BIDS-MATLAB developers
+
+  parsed_file = bids.internal.parse_filename(filename);
+  sub = parsed_file.entities.sub;
+
+  sub_idx = strcmp(['sub-' sub], {BIDS.subjects.name}');
+
+  ses_idx = true(size(sub_idx));
+  if isfield(parsed_file.entities, 'ses')
+    ses = parsed_file.entities.ses;
+    ses_idx = strcmp(['ses-' ses], {BIDS.subjects.session}');
+  end
+
+  sub_idx = find(all([sub_idx, ses_idx], 2));
+
+end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -243,6 +243,7 @@ function subject = parse_dwi(subject, schema)
         % bval & bvec file
         % ------------------------------------------------------------------
         % TODO: they can also be stored at higher levels (inheritance principle)
+        % TODO: refactor and deal with all this after file indexing
         bvalfile = bids.internal.get_metadata(fullpath_filename, '^.*%s\\.bval$');
         if isfield(bvalfile, 'filename')
           subject.dwi(end).dependencies.bval = bids.util.tsvread(bvalfile.filename);
@@ -476,6 +477,12 @@ end
 
 function BIDS = manage_intended_for(BIDS)
 
+  % Loops through all the files with potential ``intentedFor`` metadata
+  % and creates an ``intended_for`` field with the fullpath list of all the target files
+  % it is intended for that exist.
+  %
+  % Also update the structure of each target file with an ``informed_by`` field
+
   suffix_with_intended_for = { ...
                               'phasediff'; ...
                               'phase1'; ...
@@ -503,9 +510,14 @@ function BIDS = manage_intended_for(BIDS)
           intended_for;
 
       % update "dependency" field of target file
+      informed_by = [];
       for iTargetFile = 1:size(intended_for, 1)
         info_tgt = bids.internal.return_file_info(BIDS, intended_for{iTargetFile});
 
+        % TODO: this should probably check that the informed_by field does not
+        % already exist in the structure
+        % TODO: This assumes that a file will only be informed by a single file from
+        % this moodality
         informed_by.(info_src.modality) = file_list{iFile};
         BIDS.subjects(info_tgt.sub_idx).(info_tgt.modality)(info_tgt.file_idx).informed_by = ...
             informed_by;

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -468,17 +468,21 @@ end
 function structure = manage_tsv(structure, pth, filename)
 
   ext = bids.internal.file_utils(filename, 'ext');
-  p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, ['.' ext], ['\.' ext]) '$']);
+  tsv_file = bids.internal.file_utils('FPList', ...
+                                      pth,  ...
+                                      ['^' strrep(filename, ['.' ext], ['\.' ext]) '$']);
 
-  if isempty(p)
+  if isempty(tsv_file)
     warning('Missing: %s', fullfile(pth, filename));
 
   else
-    structure.content = bids.util.tsvread(p);
+    structure.content = bids.util.tsvread(tsv_file);
 
-    p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, ['.' ext], '\.json') '$']);
-    if ~isempty(p)
-      structure.meta = bids.util.jsondecode(p);
+    tsv_file = bids.internal.file_utils('FPList', ...
+                                        pth,  ...
+                                        ['^' strrep(filename, ['.' ext], '\.json') '$']);
+    if ~isempty(tsv_file)
+      structure.meta = bids.util.jsondecode(tsv_file);
     end
 
   end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -186,29 +186,6 @@ function subject = parse_using_schema(subject, modality, schema)
 
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
 
-      % Loaded
-      % events
-      % channels
-      % electrodes
-
-      % Not loaded because takes too long during indexing
-      % stim
-      % physio
-      if ~isempty(subject.(modality)) && ...
-          strcmp(subject.(modality)(end).ext, '.tsv')
-
-        subject.(modality)(end).content = [];
-        subject.(modality)(end).meta = [];
-
-        subject.(modality)(end) = manage_tsv( ...
-                                             subject.(modality)(end), ...
-                                             pth, ...
-                                             subject.(modality)(end).filename);
-
-      end
-
-      % case {'coordsystem'}
-
     end
 
   end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -226,17 +226,25 @@ function subject = parse_dwi(subject, schema)
 
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
 
-      % bval & bvec file
-      % ------------------------------------------------------------------
-      % TODO: they can also be stored at higher levels (inheritance principle)
-      bvalfile = bids.internal.get_metadata(file_list{i}, '^.*%s\\.bval$');
-      if isfield(bvalfile, 'filename')
-        subject.dwi(end).bval = bids.util.tsvread(bvalfile.filename);
-      end
+      % if this file is a nifti image we add the bval and bvec as dependencies
+      if ~isempty(subject.(modality)) && ...
+              any(strcmp(subject.(modality)(end).ext, {'.nii', '.nii.gz'}))
 
-      bvecfile = bids.internal.get_metadata(file_list{i}, '^.*%s\\.bvec$');
-      if isfield(bvalfile, 'filename')
-        subject.dwi(end).bvec = bids.util.tsvread(bvecfile.filename);
+        fullpath_filename = fullfile(subject.path, modality, file_list{i});
+
+        % bval & bvec file
+        % ------------------------------------------------------------------
+        % TODO: they can also be stored at higher levels (inheritance principle)
+        bvalfile = bids.internal.get_metadata(fullpath_filename, '^.*%s\\.bval$');
+        if isfield(bvalfile, 'filename')
+          subject.dwi(end).dependencies.bval = bids.util.tsvread(bvalfile.filename);
+        end
+
+        bvecfile = bids.internal.get_metadata(fullpath_filename, '^.*%s\\.bvec$');
+        if isfield(bvalfile, 'filename')
+          subject.dwi(end).dependencies.bvec = bids.util.tsvread(bvecfile.filename);
+        end
+
       end
 
     end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -181,13 +181,16 @@ function subject = parse_using_schema(subject, modality, schema)
 
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
 
-      if ~isempty(subject.(modality)) && strcmp(subject.(modality)(end).ext, '.tsv')
-        % events
-        % stim
-        % channels
-        % electrodes
-        %
-        % does not cover physio.tsv.gz or stim.tsv.gz
+      % Loaded
+          % events
+          % channels
+          % electrodes
+      
+      % Not loaded because takes too long during indexing
+          % stim
+          % physio
+      if ~isempty(subject.(modality)) && ...
+          strcmp(subject.(modality)(end).ext, '.tsv')
 
         subject.(modality)(end).content = [];
         subject.(modality)(end).meta = [];
@@ -199,7 +202,7 @@ function subject = parse_using_schema(subject, modality, schema)
 
       end
 
-      % case {'photo', 'coordsystem'}
+      % case {'coordsystem'}
 
     end
 
@@ -438,8 +441,8 @@ function file_list = return_file_list(modality, subject, schema)
 
   % TODO
   % this does not cover coordsystem.json
-
   % jn to omit json but not .pos file for headshape.pos
+
   pattern = '_([a-zA-Z0-9]+){1}\\..*[^jn]';
   if isempty(schema)
     pattern = '_([a-zA-Z0-9]+){1}\\..*';
@@ -464,7 +467,8 @@ end
 
 function structure = manage_tsv(structure, pth, filename)
 
-  p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, '.tsv', '\.tsv') '$']);
+  ext = bids.internal.file_utils(filename, 'ext');
+  p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, ['.' ext], ['\.' ext]) '$']);
 
   if isempty(p)
     warning('Missing: %s', fullfile(pth, filename));
@@ -472,7 +476,7 @@ function structure = manage_tsv(structure, pth, filename)
   else
     structure.content = bids.util.tsvread(p);
 
-    p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, '.tsv', '\.json') '$']);
+    p = bids.internal.file_utils('FPList', pth,  ['^' strrep(filename, ['.' ext], '\.json') '$']);
     if ~isempty(p)
       structure.meta = bids.util.jsondecode(p);
     end

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -82,7 +82,7 @@ function result = query(BIDS, query, varargin)
     case {'modalities', 'data'}
       result = result';
 
-    case 'metadata'
+    case {'metadata', 'dependencies'}
       if numel(result) == 1
         result = result{1};
       end

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -220,7 +220,7 @@ function result = perform_query(BIDS, query, options, subjects, modalities, targ
               if isfield(d(k), 'filename')
 
                 f = fullfile(BIDS.subjects(i).path, modalities{j}, d(k).filename);
-                result{end + 1} = bids.internal.get_metadata(f);
+                result{end + 1, 1} = bids.internal.get_metadata(f);
                 if ~isempty(target)
                   try
                     result{end} = subsref(result{end}, target);
@@ -257,7 +257,7 @@ function result = perform_query(BIDS, query, options, subjects, modalities, targ
 
             case 'dependencies'
               if isfield(d(k), 'dependencies')
-                result{end + 1} = d(k).dependencies;
+                result{end + 1, 1} = d(k).dependencies;
               end
 
           end

--- a/tests/test_bids_query.m
+++ b/tests/test_bids_query.m
@@ -5,19 +5,6 @@ function test_suite = test_bids_query %#ok<*STOUT>
   end
   initTestSuite;
 
-  % Test BIDS queries
-  % This dataset comes from https://github.com/bids-standard/bids-examples
-  % and is downloaded automatically by the continuous integration framework
-  % and is required for the tests to be run.
-  % Based on https://en.wikibooks.org/wiki/SPM/BIDS#BIDS_parser_and_queries
-  % __________________________________________________________________________
-  %
-  % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
-  %   The brain imaging data structure, a format for organizing and
-  %   describing outputs of neuroimaging experiments.
-  %   K. J. Gorgolewski et al, Scientific Data, 2016.
-  % __________________________________________________________________________
-
   % Copyright (C) 2019, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   % Copyright (C) 2019--, BIDS-MATLAB developers
 

--- a/tests/test_bids_query_asl.m
+++ b/tests/test_bids_query_asl.m
@@ -48,6 +48,8 @@ function test_bids_query_asl_basic()
   basename = bids.internal.file_utils(filename, 'basename');
   assertEqual(basename, {'sub-Sub103_m0scan.nii'});
 
+  assert(isfield(BIDS.subjects.perf(4), 'intended_for'));
+
   %% 'asl003'
   BIDS = bids.layout(fullfile(pth_bids_example, 'asl003'));
 
@@ -69,5 +71,8 @@ function test_bids_query_asl_basic()
   filename = bids.query(BIDS, 'data', 'suffix', 'm0scan', 'dir', 'pa');
   basename = bids.internal.file_utils(filename, 'basename');
   assertEqual(basename, {'sub-Sub1_dir-pa_m0scan.nii'});
+
+  assert(isfield(BIDS.subjects.fmap, 'intended_for'));
+  assert(isfield(BIDS.subjects.perf(4), 'intended_for'));
 
 end

--- a/tests/test_bids_query_asl.m
+++ b/tests/test_bids_query_asl.m
@@ -31,9 +31,9 @@ function test_bids_query_asl_basic()
   meta = bids.query(BIDS, 'metadata', 'sub', 'Sub103', 'suffix', 'asl');
 
   dependencies = bids.query(BIDS, 'dependencies', 'sub', 'Sub103', 'suffix', 'asl');
-  dependencies{1}.labeling_image;
-  dependencies{1}.context;
-  dependencies{1}.m0;
+  assertEqual(dependencies.labeling_image.filename, 'sub-Sub103_asllabeling.jpg');
+  dependencies.context;
+  dependencies.m0;
 
   %% 'asl002'
   BIDS = bids.layout(fullfile(pth_bids_example, 'asl002'));

--- a/tests/test_bids_query_dwi.m
+++ b/tests/test_bids_query_dwi.m
@@ -8,20 +8,26 @@ end
 
 function test_bids_query_dwi_basic()
   %
-  %   eeg queries
+  %   dwi queries
   %
 
   pth_bids_example = get_test_data_dir();
 
   %%
-  BIDS = bids.layout(fullfile(pth_bids_example, 'ds000117'));
+  BIDS = bids.layout(fullfile(pth_bids_example, 'eeg_rest_fmri'));
 
-  modalities = {'anat',    'beh',    'dwi',    'fmap',    'func',    'meg'};
+  modalities = {'anat',    'dwi',    'eeg', 'func'};
   assertEqual(bids.query(BIDS, 'modalities'), modalities);
 
-  suffixes = {'T1w', 'bold', 'dwi', 'events', 'headshape', ...
-              'magnitude1', 'magnitude2', 'meg', 'phasediff'};
-  % Missing: 'FLASH'
+  suffixes = {'T1w', 'bold', 'dwi', 'eeg'};
   assertEqual(bids.query(BIDS, 'suffixes'), suffixes);
+
+  dependencies = bids.query(BIDS, 'dependencies', ...
+                            'sub', '32', ...
+                            'acq', 'NODDI10DIR', ...
+                            'suffix', 'dwi', ...
+                            'extension', '.nii.gz');
+
+  assertEqual(dependencies.bval(1:11), [0 repmat(2400, 1, 10)]);
 
 end

--- a/tests/test_bids_query_fmap.m
+++ b/tests/test_bids_query_fmap.m
@@ -16,4 +16,8 @@ function test_query_extension()
   BIDS.subjects(1).fmap(3).intended_for;
   BIDS.subjects(1).func(1).informed_by;
 
+  BIDS = bids.layout(fullfile(pth_bids_example, 'hcp_example_bids')); % sub-100307
+
+  BIDS.subjects(1).fmap(3).intended_for{1};
+
 end

--- a/tests/test_bids_query_fmap.m
+++ b/tests/test_bids_query_fmap.m
@@ -1,0 +1,19 @@
+function test_suite = test_bids_query_fmap %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+
+end
+
+function test_query_extension()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, '7t_trt'));
+
+  BIDS.subjects(1).fmap(3).intended_for;
+  BIDS.subjects(1).func(1).informed_by;
+
+end

--- a/tests/test_bids_query_func.m
+++ b/tests/test_bids_query_func.m
@@ -15,6 +15,4 @@ function test_bids_query_func_basic()
 
   BIDS = bids.layout(fullfile(pth_bids_example, 'ds001'));
 
-  BIDS.subjects(1).func(2).content;
-
 end

--- a/tests/test_bids_query_func.m
+++ b/tests/test_bids_query_func.m
@@ -1,0 +1,21 @@
+function test_suite = test_bids_query_func %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+end
+
+function test_bids_query_func_basic()
+  %
+  %   func queries
+  %
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, 'ds001'));
+
+  BIDS.subjects(1).func(2).content;
+
+
+end

--- a/tests/test_bids_query_func.m
+++ b/tests/test_bids_query_func.m
@@ -17,5 +17,4 @@ function test_bids_query_func_basic()
 
   BIDS.subjects(1).func(2).content;
 
-
 end

--- a/tests/test_bids_query_meg.m
+++ b/tests/test_bids_query_meg.m
@@ -22,7 +22,8 @@ function test_bids_query_meg_basic()
   % missing: 'coordsystem'
   assertEqual(bids.query(BIDS, 'suffixes'), suffixes);
 
-  BIDS = bids.layout(fullfile(pth_bids_example, 'ds000247'));
-  BIDS = bids.layout(fullfile(pth_bids_example, 'ds000248'));
+  % smoke tests
+  %   BIDS = bids.layout(fullfile(pth_bids_example, 'ds000247'));
+  %   BIDS = bids.layout(fullfile(pth_bids_example, 'ds000248'));
 
 end

--- a/tests/test_get_metadata.m
+++ b/tests/test_get_metadata.m
@@ -56,3 +56,18 @@ function test_get_metadata_basic()
   assertEqual(metadata.Manufacturer, anat_sub_01.Manufacturer);
 
 end
+
+function test_get_metadata_internal()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, 'ds000117'));
+
+  bids.internal.get_metadata( ...
+                             fullfile( ...
+                                      BIDS(1).subjects(2).path, ...
+                                      'anat', ...
+                                      BIDS(1).subjects(2).anat(1).filename), ...
+                             '%s');
+
+end

--- a/tests/test_return_file_index.m
+++ b/tests/test_return_file_index.m
@@ -1,0 +1,28 @@
+function test_suite = test_return_file_index %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+
+end
+
+function test_return_file_index_basic()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, '7t_trt'));
+
+  filename = 'sub-01_ses-1_run-1_magnitude1.nii.gz';
+
+  file_idx = bids.internal.return_file_index(BIDS, 'fmap', filename);
+
+  assertEqual(file_idx, 1);
+
+  filename = 'sub-03_ses-1_T1w.nii.gz';
+
+  file_idx = bids.internal.return_file_index(BIDS, 'anat', filename);
+
+  assertEqual(file_idx, 2);
+
+end

--- a/tests/test_return_subject_index.m
+++ b/tests/test_return_subject_index.m
@@ -1,0 +1,37 @@
+function test_suite = test_return_subject_index %#ok<*STOUT>
+  try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+    test_functions = localfunctions(); %#ok<*NASGU>
+  catch % no problem; early Matlab versions can use initTestSuite fine
+  end
+  initTestSuite;
+
+end
+
+function test_return_subject_index_basic()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, '7t_trt'));
+
+  filename = 'sub-01_ses-1_run-1_magnitude1.nii.gz';
+
+  sub_idx = bids.internal.return_subject_index(BIDS, filename);
+
+  assertEqual(sub_idx, 1);
+
+  filename = 'sub-01_ses-2_run-1_magnitude1.nii.gz';
+
+  sub_idx = bids.internal.return_subject_index(BIDS, filename);
+
+  assertEqual(sub_idx, 2);
+
+  % test subject with no session folder
+  BIDS = bids.layout(fullfile(pth_bids_example, 'asl002'));
+
+  filename = 'sub-Sub103_asl.nii.gz';
+
+  sub_idx = bids.internal.return_subject_index(BIDS, filename);
+
+  assertEqual(sub_idx, 1);
+
+end


### PR DESCRIPTION
- [x] anything to do with files with a potential `intendedFor` metadata field is done after the index of the dataset
- [x] the `intended_for` field of file X contains the fullpath of all the existing target files that X is actually intended for
- [x] each target file of the `intendedFor` list of file X get an `informed_by` field with the fullpath for X

Does not include a way to query the `intended_for` or `informed_by` field.

---

For reviewers:

This is more on the implementation side, but in terms of "output" I am wondering what would the most useful for users. Ideally, this approach would then be extended to `events` and other "associated files".

- should `informed_by` (pybids uses this I think) replace the `dependencies` field? Which one is more "intuitive"?


See example below

```matlab
BIDS = bids.layout(fullfile(pth_bids_example, 'asl004'));

>> BIDS.subjects.fmap

ans = 

  struct with fields:

        filename: 'sub-Sub1_dir-pa_m0scan.nii.gz'
             ext: '.nii.gz'
          suffix: 'm0scan'
        entities: [1×1 struct]
            meta: [1×1 struct]
    intended_for: {'/home/remi/github/BIDS-matlab/tests/bids-examples/asl004/sub-Sub1/perf/sub-Sub1_m0scan.nii.gz'}


>> BIDS.subjects.perf(1)

ans = 

  struct with fields:

        filename: 'sub-Sub1_asl.nii.gz'
             ext: '.nii.gz'
          suffix: 'asl'
        entities: [1×1 struct]
            meta: [1×1 struct]
    dependencies: [1×1 struct]
     informed_by: [1×1 struct]
    intended_for: []

>> BIDS.subjects.perf(1).informed_by.perf

ans =

    '/home/remi/github/BIDS-matlab/tests/bids-examples/asl004/sub-Sub1/perf/sub-Sub1_m0scan.nii.gz'

>> BIDS.subjects.perf(4)

ans = 

  struct with fields:

        filename: 'sub-Sub1_m0scan.nii.gz'
             ext: '.nii.gz'
          suffix: 'm0scan'
        entities: [1×1 struct]
            meta: [1×1 struct]
    dependencies: ''
     informed_by: [1×1 struct]
    intended_for: {'/home/remi/github/BIDS-matlab/tests/bids-examples/asl004/sub-Sub1/perf/sub-Sub1_asl.nii.gz'}


>> BIDS.subjects.perf(4).informed_by.fmap

ans =

    '/home/remi/github/BIDS-matlab/tests/bids-examples/asl004/sub-Sub1/fmap/sub-Sub1_dir-pa_m0scan.nii.gz'
```

