### PR TITLE
Improvements on dependencies calculations

### DIFF
--- a/+bids/+internal/append_to_layout.m
+++ b/+bids/+internal/append_to_layout.m
@@ -43,8 +43,6 @@ function subject = append_to_layout(file, subject, modality, schema)
     if ~isempty(p) && strcmp(p.ext, '.json')
       return
     end
-    file
-    p.metafile = bids.internal.get_meta_list(file)
 
   end
 

--- a/+bids/+internal/append_to_layout.m
+++ b/+bids/+internal/append_to_layout.m
@@ -43,6 +43,8 @@ function subject = append_to_layout(file, subject, modality, schema)
     if ~isempty(p) && strcmp(p.ext, '.json')
       return
     end
+    file
+    p.metafile = bids.internal.get_meta_list(file)
 
   end
 

--- a/+bids/+internal/endsWith.m
+++ b/+bids/+internal/endsWith.m
@@ -1,0 +1,23 @@
+function res = endsWith(str, pat)
+  %
+  % Checks id character array 'str' ends with 'pat'
+  %
+  % USAGE  res = bids.internal.endsWith(str, pat)
+  %
+  % str        - character array
+  % pat        - character array
+  %
+  % __________________________________________________________________________
+  %
+  % Based on spm_file.m and spm_select.m from SPM12.
+  % __________________________________________________________________________
+
+  % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  res = false;
+  l_pat = length(pat);
+  if l_pat > length(str)
+    return;
+  end
+  res = strcmp(str(end - l_pat +1 : end), pat);
+
+end

--- a/+bids/+internal/get_meta_list.m
+++ b/+bids/+internal/get_meta_list.m
@@ -1,0 +1,82 @@
+function metalist = get_meta_list(filename, pattern)
+  %
+  % Read a BIDS's file metadata according to the inheritance principle
+  %
+  % USAGE::
+  %
+  %    meta = bids.internal.get_metadata(filename, pattern = '^.*%s\\.json$')
+  %
+  % :param filename: fullpath name of file following BIDS standard
+  % :type  filename: string
+  % :param pattern:  Regular expression matching the metadata file (default is ``'^.*%s\\.json$'``)
+  %                  If provided, it must at least be ``'%s'``.
+  % :type  pattern:  string
+  %
+  %
+  % metalist    - list of paths to metafiles
+  % __________________________________________________________________________
+
+  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % Copyright (C) 2018--, BIDS-MATLAB developers
+
+  if nargin == 1
+    pattern = '^.*%s\\.json$';
+  end
+
+  pth = fileparts(filename);
+  p = bids.internal.parse_filename(filename);
+  metalist = {};
+
+  N = 3;
+
+  % -There is a session level in the hierarchy
+  if isfield(p.entities, 'ses') && ~isempty(p.entities.ses)
+    N = N + 1;
+  end
+
+  % -Loop from the directory where the file of interest is back to the
+  % top level of the BIDS hierarchy
+  for n = 1:N
+
+    % -List the potential metadata files associated with this file suffix type
+    % Default is to assume it is a JSON file
+    metafile = bids.internal.file_utils('FPList', pth, sprintf(pattern, p.suffix));
+
+    if isempty(metafile)
+      metafile = {};
+    else
+      metafile = cellstr(metafile);
+    end
+
+    % -For all those files we find which one is potentially associated with
+    % the file of interest
+    for i = 1:numel(metafile)
+
+      p2 = bids.internal.parse_filename(metafile{i});
+      entities = {};
+      if isfield(p2, 'entities')
+        entities = fieldnames(p2.entities);
+      end
+
+      % -Check if this metadata file contains the same entity-label pairs as its
+      % data file counterpart
+      ismeta = true;
+      for j = 1:numel(entities)
+        if ~isfield(p.entities, entities{j}) || ...
+                ~strcmp(p.entities.(entities{j}), p2.entities.(entities{j}))
+          ismeta = false;
+          break
+        end
+      end
+
+      % append path to list
+      if ismeta
+        metalist{end + 1} = metafile{i};
+      end
+
+    end
+
+    % -Go up to the parent folder
+    pth = fullfile(pth, '..');
+  end
+end

--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -1,16 +1,13 @@
-function meta = get_metadata(filename, pattern)
+function meta = get_metadata(metafile)
   %
   % Read a BIDS's file metadata according to the inheritance principle
   %
   % USAGE::
   %
-  %    meta = bids.internal.get_metadata(filename, pattern = '^.*%s\\.json$')
+  %    meta = bids.internal.get_metadata(metafile)
   %
-  % :param filename: fullpath name of file following BIDS standard
-  % :type  filename: string
-  % :param pattern:  Regular expression matching the metadata file (default is ``'^.*%s\\.json$'``)
-  %                  If provided, it must at least be ``'%s'``.
-  % :type  pattern:  string
+  % :param metafile: list of fullpath names of metafiles
+  % :type  metafile: string or array of strings
   %
   %
   % meta        - metadata structure
@@ -19,76 +16,19 @@ function meta = get_metadata(filename, pattern)
   % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   % Copyright (C) 2018--, BIDS-MATLAB developers
 
-  if nargin == 1
-    pattern = '^.*%s\\.json$';
-  end
-
-  pth = fileparts(filename);
-  p = bids.internal.parse_filename(filename);
-
   meta = struct();
+  metafile = cellstr(metafile);
 
-  N = 3;
-
-  % -There is a session level in the hierarchy
-  if isfield(p.entities, 'ses') && ~isempty(p.entities.ses)
-    N = N + 1;
-  end
-
-  % -Loop from the directory where the file of interest is back to the
-  % top level of the BIDS hierarchy
-  for n = 1:N
-
-    % -List the potential metadata files associated with this file suffix type
-    % Default is to assume it is a JSON file
-    metafile = bids.internal.file_utils('FPList', pth, sprintf(pattern, p.suffix));
-
-    if isempty(metafile)
-      metafile = {};
+  for i = 1:numel(metafile)
+    if endsWith(metafile{i}, '.json')
+      meta = update_metadata(meta, bids.util.jsondecode(metafile{i}), metafile{i});
     else
-      metafile = cellstr(metafile);
+      meta.filename = metafile{i};
     end
-
-    % -For all those files we find which one is potentially associated with
-    % the file of interest
-    for i = 1:numel(metafile)
-
-      p2 = bids.internal.parse_filename(metafile{i});
-      entities = {};
-      if isfield(p2, 'entities')
-        entities = fieldnames(p2.entities);
-      end
-
-      % -Check if this metadata file contains the same entity-label pairs as its
-      % data file counterpart
-      ismeta = true;
-      for j = 1:numel(entities)
-        if ~isfield(p.entities, entities{j}) || ...
-                ~strcmp(p.entities.(entities{j}), p2.entities.(entities{j}))
-          ismeta = false;
-          break
-        end
-      end
-
-      % -Read the content of the metadata file if it is a JSON file and update
-      % the metadata concerning the file of interest otherwise store the filename
-      if ismeta
-        if strcmp(p2.ext, '.json')
-          meta = update_metadata(meta, bids.util.jsondecode(metafile{i}), metafile{i});
-        else
-          meta.filename = metafile{i};
-        end
-      end
-
-    end
-
-    % -Go up to the parent folder
-    pth = fullfile(pth, '..');
-
   end
 
   if isempty(meta)
-    warning('No metadata for %s', filename);
+    warning('No metadata for %s', metafile);
   end
 
 end

--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -20,7 +20,7 @@ function meta = get_metadata(metafile)
   metafile = cellstr(metafile);
 
   for i = 1:numel(metafile)
-    if endsWith(metafile{i}, '.json')
+    if bids.internal.endsWith(metafile{i}, '.json')
       meta = update_metadata(meta, bids.util.jsondecode(metafile{i}), metafile{i});
     else
       meta.filename = metafile{i};

--- a/+bids/+internal/startsWith.m
+++ b/+bids/+internal/startsWith.m
@@ -1,0 +1,23 @@
+function res = startsWith(str, pat)
+  %
+  % Checks id character array 'str' starts with 'pat'
+  %
+  % USAGE  res = bids.internal.startsWith(str, pat)
+  %
+  % str        - character array
+  % pat        - character array
+  %
+  % __________________________________________________________________________
+  %
+  % Based on spm_file.m and spm_select.m from SPM12.
+  % __________________________________________________________________________
+
+  % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  res = false;
+  l_pat = length(pat);
+  if l_pat > length(str)
+    return;
+  end
+  res = strcmp(str(1 : l_pat), pat);
+
+end

--- a/+bids/derivate.m
+++ b/+bids/derivate.m
@@ -1,0 +1,138 @@
+function derivatives = derivate(BIDS, out_path, name, varargin)
+  %
+  % Copy selected data from BIDS layout to given derivatives folder,
+  % returning layout of new derivatives folder
+  %
+  % USAGE::
+  %
+  %   derivatives = derivate(BIDS, out_path, ...)
+  %
+  % :param BIDS:     BIDS directory name or BIDS structure (from bids.layout)
+  % :type  BIDS:     (strcuture or string)
+  % :param out_path: path to directory containing the derivatives
+  % :type  out_path: string
+  % :param name:     name of pipeline to use
+  % :type  name:     string
+  %
+  %
+  % __________________________________________________________________________
+  %
+  % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
+  %   The brain imaging data structure, a format for organizing and
+  %   describing outputs of neuroimaging experiments.
+  %   K. J. Gorgolewski et al, Scientific Data, 2016.
+  % __________________________________________________________________________
+
+  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % Copyright (C) 2018--, BIDS-MATLAB developers
+
+  narginchk(3, Inf);
+
+  BIDS = bids.layout(BIDS);
+
+  if ~exist(out_path, 'dir')
+    error(['Output path ' out_path ' not found']);
+  end
+
+  derivatives = [];
+  data_list = bids.query(BIDS, 'data', varargin{:});
+  subjects_list = bids.query(BIDS, 'subjects', varargin{:});
+
+  if isempty(data_list)
+    warning(['No data found for this query']);
+    return;
+  else
+    fprintf('Found %d files in %d subjects\n', length(data_list), length(subjects_list));
+  end
+
+  pth_BIDSderiv = fullfile(out_path, name);
+  if ~exist(pth_BIDSderiv,'dir')
+    mkdir(pth_BIDSderiv);
+  end
+
+  % creating description
+  descr_file = fullfile(pth_BIDSderiv, 'dataset_description.json');
+  pipeline.Name = mfilename;
+  % pipeline.Verion = ?
+  pipeline.Container = varargin;
+
+  % loading dataset description
+  if exist(descr_file, 'file')
+    description = bids.util.jsondecode(descr_file);
+  else
+    description = BIDS.description;
+  end
+
+  % updating GeneratedBy
+  if isfield(description, 'GeneratedBy')
+    description.GeneratedBy = [description.GeneratedBy pipeline];
+  else
+    description.GeneratedBy = [pipeline];
+  end
+
+  bids.util.jsonencode(descr_file, description, 'Indent', '  ');
+
+  % extracting participants.tsv file?
+
+  % looping over selected files
+  for iFile = 1:numel(data_list)
+    copy_file(BIDS, pth_BIDSderiv, data_list{iFile});
+  end
+
+end
+
+function status = copy_file(BIDS, derivatives_folder, data_file)
+  status = 1;
+  info = bids.internal.return_file_info(BIDS, data_file);
+  file = BIDS.subjects(info.sub_idx).(info.modality)(info.file_idx);
+  basename = file.filename(1:end - length(file.ext));
+  out_dir = fullfile(derivatives_folder,...
+                     BIDS.subjects(info.sub_idx).name,...
+                     BIDS.subjects(info.sub_idx).session,...
+                     info.modality);
+  out_path = fullfile(out_dir, basename);
+  meta_file = [out_path '.json'];
+
+  % ignore already existing files; avoid circular references
+  if exist(meta_file) 
+    return
+  end
+  if ~exist(out_dir, 'dir')
+    mkdir(out_dir);
+  end
+  % copy data file
+  if endsWith(file.ext, '.gz')
+    gunzip(data_file, out_dir);
+  else
+    [status,message,messageId] = copyfile(data_file, [out_path file.ext]);
+  end
+  if ~status
+    warning([messageId ': ' message]);
+    return;
+  end
+  % export metadata
+  if ~strcmpi(file.ext, '.json') % skip if data file is json
+    bids.util.jsonencode(meta_file, file.meta);
+  end
+
+  % checking that json is created
+  if ~exist(meta_file)
+    error(['Failed to create sidecar json file: ' meta_file]);
+  end
+
+  % trating depandencies
+  if ~isempty(file.dependencies)
+    dependencies = fieldnames(file.dependencies);
+    for dep = 1:numel(dependencies)
+      for idep = 1: numel(file.dependencies.(dependencies{dep}))
+        dep_file = file.dependencies.(dependencies{dep}){idep};
+        if exist(dep_file, 'file')
+          copy_file(BIDS, derivatives_folder, dep_file);
+        else
+          warning(['Dependency file ' dep_file ' not found']);
+        end
+      end
+    end
+  end
+
+end

--- a/+bids/derivate.m
+++ b/+bids/derivate.m
@@ -101,7 +101,7 @@ function status = copy_file(BIDS, derivatives_folder, data_file)
     mkdir(out_dir);
   end
   % copy data file
-  if endsWith(file.ext, '.gz')
+  if bids.internal.endsWith(file.ext, '.gz')
     gunzip(data_file, out_dir);
   else
     [status,message,messageId] = copyfile(data_file, [out_path file.ext]);

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -197,7 +197,7 @@ function subject = parse_using_schema(subject, modality, schema)
         if strcmp(candidates{ii}, file_list{i})
           continue;
         end
-        if endsWith(candidates{ii}, '.json')
+        if bids.internal.endsWith(candidates{ii}, '.json')
           continue
         end
         match = regexp(candidates{ii}, ['_' suffix '\..*$'], 'match');
@@ -246,7 +246,7 @@ function subject = parse_perf(subject, schema)
         if strcmp(candidates{ii}, file_list{i})
           continue;
         end
-        if endsWith(candidates{ii}, '.json')
+        if bids.internal.endsWith(candidates{ii}, '.json')
           continue
         end
         match = regexp(candidates{ii}, ['_' suffix '\..*$'], 'match');

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -209,26 +209,30 @@ function subject = parse_dwi(subject, schema)
 
     for i = 1:numel(file_list)
 
+      fullpath_filename = fullfile(pth, file_list{i});
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
+      subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
 
       % if this file is a nifti image we add the bval and bvec as dependencies
       if ~isempty(subject.(modality)) && ...
               any(strcmp(subject.(modality)(end).ext, {'.nii', '.nii.gz'}))
 
-        fullpath_filename = fullfile(subject.path, modality, file_list{i});
-
         % bval & bvec file
         % ------------------------------------------------------------------
         % TODO: they can also be stored at higher levels (inheritance principle)
         % TODO: refactor and deal with all this after file indexing
-        bvalfile = bids.internal.get_metadata(fullpath_filename, '^.*%s\\.bval$');
-        if isfield(bvalfile, 'filename')
-          subject.dwi(end).dependencies.bval = bids.util.tsvread(bvalfile.filename);
+        bvalfile = bids.internal.get_meta_list(fullpath_filename, '^.*%s\\.bval$');
+        if ~isempty(bvalfile)
+          subject.dwi(end).dependencies.bval = bvalfile;
+        else
+          warning(['DWI: ' fullpath_filename ' missing bval file'])
         end
 
-        bvecfile = bids.internal.get_metadata(fullpath_filename, '^.*%s\\.bvec$');
-        if isfield(bvalfile, 'filename')
-          subject.dwi(end).dependencies.bvec = bids.util.tsvread(bvecfile.filename);
+        bvecfile = bids.internal.get_meta_list(fullpath_filename, '^.*%s\\.bvec$');
+        if ~isempty(bvalfile)
+          subject.dwi(end).dependencies.bvec = bvecfile;
+        else
+          warning(['DWI: ' fullpath_filename ' missing bvec file'])
         end
 
       end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -153,12 +153,8 @@ function subject = parse_subject(pth, subjname, sesname, schema)
     % so the parsing is unconstrained
     for iModality = 1:numel(modalities)
       switch modalities{iModality}
-        case {'anat', 'func', 'beh', 'meg', 'eeg', 'ieeg', 'pet'}
+        case {'anat', 'func', 'beh', 'meg', 'eeg', 'ieeg', 'pet', 'fmap', 'dwi'}
           subject = parse_using_schema(subject, modalities{iModality}, schema);
-        case 'dwi'
-          subject = parse_dwi(subject, schema);
-        case 'fmap'
-          subject = parse_fmap(subject, schema);
         case 'perf'
           subject = parse_perf(subject, schema);
         otherwise
@@ -190,64 +186,31 @@ function subject = parse_using_schema(subject, modality, schema)
       subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
       subject.(modality)(end).dependencies.explicit = {};
       subject.(modality)(end).dependencies.data = {};
-      subject.(modality)(end).dependencies.implicit = {};
+      subject.(modality)(end).dependencies.group = {};
 
-    end
-
-  end
-
-end
-
-function subject = parse_dwi(subject, schema)
-
-  % --------------------------------------------------------------------------
-  %  Diffusion imaging data
-  % --------------------------------------------------------------------------
-
-  modality = 'dwi';
-  pth = fullfile(subject.path, modality);
-
-  if exist(pth, 'dir')
-
-    subject = bids.internal.add_missing_field(subject, modality);
-
-    file_list = return_file_list(modality, subject, schema);
-
-    for i = 1:numel(file_list)
-
-      fullpath_filename = fullfile(pth, file_list{i});
-      subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
-      subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
-      subject.(modality)(end).dependencies.explicit = {};
-      subject.(modality)(end).dependencies.data = {};
-      subject.(modality)(end).dependencies.implicit = {};
-
-      % if this file is a nifti image we add the bval and bvec as dependencies
-      if ~isempty(subject.(modality)) && ...
-              any(strcmp(subject.(modality)(end).ext, {'.nii', '.nii.gz'}))
-
-        % bval & bvec file
-        % ------------------------------------------------------------------
-        % TODO: they can also be stored at higher levels (inheritance principle)
-        % TODO: refactor and deal with all this after file indexing
-        bvalfile = bids.internal.get_meta_list(fullpath_filename, '^.*%s\\.bval$');
-        if ~isempty(bvalfile)
-          subject.dwi(end).dependencies.bval = bvalfile;
-        else
-          warning(['DWI: ' fullpath_filename ' missing bval file'])
+      ext = subject.(modality)(end).ext;
+      suffix = subject.(modality)(end).suffix;
+      search = strrep(file_list{i}, ['_' suffix ext], '_[a-zA-Z0-9.]+$');
+      candidates = bids.internal.file_utils('List', pth, ['^' search '$']);
+      candidates = cellstr(candidates);
+      for ii = 1:numel(candidates)
+        if strcmp(candidates{ii}, file_list{i})
+          continue;
         end
-
-        bvecfile = bids.internal.get_meta_list(fullpath_filename, '^.*%s\\.bvec$');
-        if ~isempty(bvalfile)
-          subject.dwi(end).dependencies.bvec = bvecfile;
-        else
-          warning(['DWI: ' fullpath_filename ' missing bvec file'])
+        if endsWith(candidates{ii}, '.json')
+          continue
         end
-
+        match = regexp(candidates{ii}, ['_' suffix '\..*$'], 'match');
+        if isempty(match) % different suffix
+          subject.(modality)(end).dependencies.group{end+1} = fullfile(pth, candidates{ii});
+        else  % same suffix
+          subject.(modality)(end).dependencies.data{end+1} = fullfile(pth, candidates{ii});
+        end
       end
-
     end
+
   end
+
 end
 
 function subject = parse_perf(subject, schema)
@@ -270,9 +233,6 @@ function subject = parse_perf(subject, schema)
       fullpath_filename = fullfile(pth, file_list{i});
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
       subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
-      subject.(modality)(end).dependencies.explicit = {};
-      subject.(modality)(end).dependencies.data = {};
-      subject.(modality)(end).dependencies.implicit = {};
 
       switch subject.perf(i).suffix
 
@@ -298,62 +258,6 @@ function subject = parse_perf(subject, schema)
           subject.perf(i) = manage_asllabeling(subject.perf(i), pth);
 
           subject.perf(i) = manage_M0(subject.perf(i), pth);
-
-      end
-
-    end
-
-  end
-
-end
-
-function subject = parse_fmap(subject, schema)
-
-  modality = 'fmap';
-  pth = fullfile(subject.path, modality);
-
-  if exist(pth, 'dir')
-
-    subject = bids.internal.add_missing_field(subject, modality);
-
-    file_list = return_file_list(modality, subject, schema);
-
-    for i = 1:numel(file_list)
-
-      fullpath_filename = fullfile(pth, file_list{i});
-      subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
-      subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
-      subject.(modality)(end).dependencies.explicit = {};
-      subject.(modality)(end).dependencies.data = {};
-      subject.(modality)(end).dependencies.implicit = {};
-
-      switch subject.fmap(i).suffix
-
-        % -A single, real fieldmap image
-        case {'fieldmap', 'magnitude'}
-          subject.fmap(i).dependencies.magnitude = strrep(file_list{idx(i)}, ...
-                                                          '_fieldmap.nii', ...
-                                                          '_magnitude.nii');
-
-          % Phase difference image and at least one magnitude image
-        case {'phasediff'}
-          subject.fmap(i).dependencies.magnitude = { ...
-                                                    strrep(file_list{i}, ...
-                                                           '_phasediff.nii', ...
-                                                           '_magnitude1.nii'), ...
-                                                    strrep(file_list{i}, ...
-                                                           '_phasediff.nii', ...
-                                                           '_magnitude2.nii')}; % optional
-
-          % Two phase images and two magnitude images
-        case {'phase1', 'phase2'}
-          subject.fmap(i).dependencies.magnitude = { ...
-                                                    strrep(file_list{i}, ...
-                                                           '_phase1.nii', ...
-                                                           '_magnitude1.nii'), ...
-                                                    strrep(file_list{i}, ...
-                                                           '_phase1.nii', ...
-                                                           '_magnitude2.nii')};
 
       end
 

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -233,6 +233,29 @@ function subject = parse_perf(subject, schema)
       fullpath_filename = fullfile(pth, file_list{i});
       subject = bids.internal.append_to_layout(file_list{i}, subject, modality, schema);
       subject.(modality)(end).metafile = bids.internal.get_meta_list(fullpath_filename);
+      subject.(modality)(end).dependencies.explicit = {};
+      subject.(modality)(end).dependencies.data = {};
+      subject.(modality)(end).dependencies.group = {};
+
+      ext = subject.(modality)(end).ext;
+      suffix = subject.(modality)(end).suffix;
+      search = strrep(file_list{i}, ['_' suffix ext], '_[a-zA-Z0-9.]+$');
+      candidates = bids.internal.file_utils('List', pth, ['^' search '$']);
+      candidates = cellstr(candidates);
+      for ii = 1:numel(candidates)
+        if strcmp(candidates{ii}, file_list{i})
+          continue;
+        end
+        if endsWith(candidates{ii}, '.json')
+          continue
+        end
+        match = regexp(candidates{ii}, ['_' suffix '\..*$'], 'match');
+        if isempty(match) % different suffix
+          subject.(modality)(end).dependencies.group{end+1} = fullfile(pth, candidates{ii});
+        else  % same suffix
+          subject.(modality)(end).dependencies.data{end+1} = fullfile(pth, candidates{ii});
+        end
+      end
 
       switch subject.perf(i).suffix
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.asv
 *.*~
+*.swp
 
 /tests/bids-examples
 /tests/*.tsv


### PR DESCRIPTION
#### Metadata treatment
Split `get_metadata` into two functions:

- `metalist = get_meta_list(filename, pattern)` returns list of files satisfying pattern with inheritance principle
- `get_metadata(metafile)` construct meta structure from json files in passed meta-files list (from above function)

Each data file in dataset receives new field `metafile` that contains list of files from `get_meta_list`.

This will facilitate access to metafiles directly. Individual values can be extracted by  user if needed using `get_metadata`.

#### Dependencies

Each file structure contains dependencies sub-structure with guaranteed fields:

- `explicit` -- list of data files containing "IntendedFor" referencing current file.
- `data` -- list of files with same name but different extension. This will combine files that are split in header and data (like in Brainvision), also takes care of bval/bvec files
- `group` -- list of files that have same name except extension and suffix. This will group file that logically need each other, like functional mri and events tabular file. It also takes care of fmap magnitude1/2 and phasediff

Additional custom subfields can be added for given modalities.

This allow to treat `dwi` and `fmap` with generic `parse_using_schema`. `perf` likely also, but I can't certify it.

#### Issues

- [ ] performance. I feel that retrieval of dependencies can be optimised
- [ ] Tests -- was unable to install moxunit
- [ ] Tests on other datasets


