### PR TITLE
[FIX] lower priority to use SPM function to deal with json files

### DIFF
--- a/+bids/+util/jsondecode.m
+++ b/+bids/+util/jsondecode.m
@@ -21,11 +21,18 @@ function value = jsondecode(file, varargin)
 
   if has_jsondecode
     value = jsondecode(fileread(file));
-  elseif exist('spm_jsonread', 'file') == 3            % SPM12
-    value = spm_jsonread(file, varargin{:});
-  elseif exist('jsonread', 'file') == 3                % JSONio
+
+    % JSONio
+  elseif exist('jsonread', 'file') == 3
     value = jsonread(file, varargin{:});
+
+    % SPM12
+  elseif exist('spm_jsonread', 'file') == 3
+    value = spm_jsonread(file, varargin{:});
+
   else
     url = 'https://github.com/gllmflndn/JSONio';
     error('JSON library required: install JSONio from: %s', url);
   end
+
+end

--- a/+bids/+util/jsondecode.m
+++ b/+bids/+util/jsondecode.m
@@ -1,13 +1,24 @@
 function value = jsondecode(file, varargin)
-  % Decode JSON-formatted file
-  % FORMAT value = bids.util.jsondecode(file, opts)
-  % file     - name of a JSON file or JSON string
-  % opts     - structure of optional parameters (only with JSONio):
-  %              replacementStyle: string to control how non-alphanumeric
-  %              characters are replaced {'underscore','hex','delete','nop'}
-  %              [Default: 'underscore']
   %
-  % json     - JSON structure
+  % Decode JSON-formatted file
+  %
+  % USAGE::
+  %
+  %   json = bids.util.jsondecode(file, opts)
+  %
+  % :param file: name of a JSON file or JSON string
+  % :type filename: string
+  % :param opts: structure of optional parameters (only with JSONio):
+  %              - replacementStyle: string to control how non-alphanumeric
+  %                  characters are replaced [Default: ``'underscore'``]:
+  %                     - ``'underscore'``
+  %                     - ``'hex'``
+  %                     - ``'delete'``
+  %                     - ``'nop'``
+  % :type opts: structure
+  %
+  % :returns: - :json: JSON structure
+  %
 
   % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   % Copyright (C) 2018--, BIDS-MATLAB developers

--- a/+bids/+util/jsonencode.m
+++ b/+bids/+util/jsonencode.m
@@ -1,20 +1,36 @@
 function varargout = jsonencode(varargin)
+  %
   % Encode data to JSON-formatted file
-  % FORMAT bids.util.jsonencode(filename,json)
-  % filename - JSON filename
-  % json     - JSON structure
   %
-  % FORMAT S = bids.util.jsonencode(json)
-  % json     - JSON structure
-  % S        - serialized JSON structure (string)
+  % USAGE::
   %
-  % FORMAT [...] = bids.util.jsonencode(...,opts)
-  % opts     - structure of optional parameters:
-  %              Indent: string to use for indentation [Default: '']
-  %              ReplacementStyle: string to control how non-alphanumeric
-  %                characters are replaced [Default: 'underscore']
-  %              ConvertInfAndNaN: encode NaN, Inf and -Inf as "null"
-  %                [Default: true]
+  %   bids.util.jsonencode(filename, json, opts)
+  %
+  % :param filename: JSON filename
+  % :type filename: string
+  % :param json: JSON structure
+  % :type json: structure
+  %
+  %
+  % USAGE::
+  %
+  %   S = bids.util.jsonencode(json, opts)
+  %
+  % :param json: JSON structure
+  % :type json: structure
+  %
+  % :returns: - :S: (string) serialized JSON structure
+  %
+  % ---
+  %
+  % :param opts: structure of optional parameters:
+  %                 - Indent: string to use for indentation; [Default: ``''``]
+  %                 - ReplacementStyle: string to control how non-alphanumeric
+  %                    characters are replaced; [Default: ``'underscore'``]
+  %                 - ConvertInfAndNaN: encode ``NaN``, ``Inf`` and ``-Inf`` as ``"null"``;
+  %                    [Default: ``true``]
+  % :type opts: structure  -
+  %
 
   % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   % Copyright (C) 2018--, BIDS-MATLAB developers

--- a/+bids/+util/jsonencode.m
+++ b/+bids/+util/jsonencode.m
@@ -30,16 +30,15 @@ function varargout = jsonencode(varargin)
         ismember(exist('jsonencode', 'file'), [2 3]); % jsonstuff / Matlab-compatible implementation
   end
 
-  if exist('spm_jsonwrite', 'file') == 2                    % SPM12
-    [varargout{1:nargout}] = spm_jsonwrite(varargin{:});
-  elseif exist('jsonwrite', 'file') == 2                    % JSONio
-    [varargout{1:nargout}] = jsonwrite(varargin{:});
-  elseif has_jsonencode
+  if has_jsonencode
+
     file = '';
+
     if ischar(varargin{1})
       file = varargin{1};
       varargin(1) = [];
     end
+
     if numel(varargin) > 1
       opts = varargin{2};
       varargin(2) = [];
@@ -50,7 +49,9 @@ function varargout = jsonencode(varargin)
         end
       end
     end
+
     txt = jsonencode(varargin{:});
+
     if ~isempty(file)
       fid = fopen(file, 'wt');
       if fid == -1
@@ -59,8 +60,21 @@ function varargout = jsonencode(varargin)
       fprintf(fid, '%s', txt);
       fclose(fid);
     end
+
     varargout = { txt };
+
+    % JSONio
+  elseif exist('jsonwrite', 'file') == 2
+    [varargout{1:nargout}] = jsonwrite(varargin{:});
+
+    % SPM12
+  elseif exist('spm_jsonwrite', 'file') == 2
+    [varargout{1:nargout}] = spm_jsonwrite(varargin{:});
+
   else
     url = 'https://github.com/gllmflndn/JSONio';
     error('JSON library required: install JSONio from: %s', url);
+
   end
+
+end


### PR DESCRIPTION
fixes #176 

- [x] change order of priority to check which function to use to deal with JSON: built-in functions > JSONio > SPM
- [x] reformat help sections of those functions

Once merged I will also apply this fix on the `dev` branch.