### PR TITLE
improved data files regexp

### DIFF
--- a/+bids/+internal/parse_filename.m
+++ b/+bids/+internal/parse_filename.m
@@ -39,8 +39,18 @@ function p = parse_filename(filename, fields)
 
   filename = bids.internal.file_utils(filename, 'filename');
 
+  % -Identify prefix as string coming before 'sub-'
+  pos = strfind(filename, 'sub-');
+  if numel(pos) ~= 1
+    warning(['File name ' p.filename ' not bids compatible']);
+    p = struct([]);
+    return
+  end
+  p.prefix = filename(1:pos-1);
+  basename = filename(pos:end);
+
   % -Identify all the BIDS entity-label pairs present in the filename (delimited by "_")
-  [parts, dummy] = regexp(filename, '(?:_)+', 'split', 'match'); %#ok<ASGLU>
+  [parts, dummy] = regexp(basename, '(?:_)+', 'split', 'match'); %#ok<ASGLU>
   p.filename = filename;
 
   % -Identify the suffix and extension of this file
@@ -51,10 +61,6 @@ function p = parse_filename(filename, fields)
     [d, dummy] = regexp(parts{i}, '(?:\-)+', 'split', 'match'); %#ok<ASGLU>
     p.entities.(d{1}) = d{2};
   end
-
-  % identidy an eventual prefix to the file
-  tmp = regexp(parts{1}, '(sub)', 'split');
-  p.prefix = tmp{1};
 
   % -Extra fields can be added to the structure and ordered specifically.
   if nargin == 2

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -406,22 +406,39 @@ function file_list = return_file_list(modality, subject, schema)
   % this does not cover coordsystem.json
   % jn to omit json but not .pos file for headshape.pos
 
-  pattern = '_([a-zA-Z0-9]+){1}\\..*[^jn]';
-  prefix = '';
-  if isempty(schema)
-    pattern = '_([a-zA-Z0-9]+){1}\\..*';
-    prefix = '([a-zA-Z0-9]*)';
+ % prefix only for shemaless data
+ if isempty(schema)
+    prefix = '^([a-zA-Z0-9_]*)';
+  else
+    prefix = '^';
   end
+
+  % sub and ses part
+  pattern = [prefix subject.name '_'];
+  if ~isempty(subject.session)
+    pattern = [pattern subject.session '_'];
+  end
+
+  % entities
+  pattern = [pattern '([a-zA-Z0-9]+-[a-zA-Z0-9]+_)*'];
+
+  % suffix
+  pattern = [pattern '([a-zA-Z0-9]+\.){1}'];
+
+  % extention
+  pattern = [pattern '(?!.json)([a-zA-Z0-9.]+){1}$'];
 
   pth = fullfile(subject.path, modality);
 
   [file_list, d] = bids.internal.file_utils('List', ...
                                             pth, ...
-                                            sprintf(['^' prefix '%s.*' pattern '$'], ...
-                                                    subject.name));
+                                            pattern);
 
   file_list = convert_to_cell(file_list);
 
+  % I wish to to remove 'strcmp(modality, 'meg') &&'
+  % just to cover eventual other modalities that stores data
+  % in folders
   if strcmp(modality, 'meg') && ~isempty(d)
     for i = 1:size(d, 1)
       file_list{end + 1, 1} = d(i, :);


### PR DESCRIPTION
Affined the file search regexp, should not conflict with anything.

Reason: SPM sometimes not only add a prefix, but also a suffix for temporary files. And the original queries accepts such files.
The original suffix is treated as entity, and crashes when tries to split by '-'

In layout:

  - requesting strart with `sub-<subId>_ses-<sesId>_`
  - requesting a set of entities of form `<key>-<value>_`
  - requestin exactly one suffix

In parse_filename

  - Defining prefix as everything coming before `sub-`
  - Checking that only one `sub-` is present