### PR TITLE
Added check for data consistency

### DIFF
--- a/+bids/+util/check_data_consistency.m
+++ b/+bids/+util/check_data_consistency.m
@@ -1,0 +1,123 @@
+function check_data_consistency(to_check, varargin)
+  %
+  % Given a set of filepaths cellarrays from bids.query, checks that any
+  % all paths at same index have consistent bids name and same size
+  % Raise error if inconsistency found
+  %
+  % Options:
+  %   allow_duplicates  -- if set, will allow duplicated filenames
+  %   same_suffix -- if set, files must have same suffix
+  %   same_extention -- if set, files must have same extention
+  %
+  % USAGE::
+  %
+  %   bids.util.check_data_consistency([data1, data2, data3])
+  %
+  %
+  % __________________________________________________________________________
+  %
+  % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
+  %   The brain imaging data structure, a format for organizing and
+  %   describing outputs of neuroimaging experiments.
+  %   K. J. Gorgolewski et al, Scientific Data, 2016.
+  % __________________________________________________________________________
+  %
+  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % Copyright (C) 2018--, BIDS-MATLAB developers
+
+  %% Validate input arguments
+  % ==========================================================================
+
+  allow_duplicates = false;
+  same_suffix = false;
+  same_extention = false;
+
+  if isempty(to_check)
+    error('No data selected');
+  end
+
+  for ii = 1:size(varargin, 1)
+    if strcmp(varargin{ii}, 'allow_duplicates')
+      allow_duplicates = true;
+    elseif strcmp(varargin{ii}, 'same_suffix')
+      same_suffix = true;
+    elseif strcmp(varargin{ii}, 'same_extention')
+      same_extention = true;
+    else 
+      error(['Unrecognised option ' varargin{ii}]);
+    end
+  end
+
+  for iFile = 1:size(to_check, 1)
+    [pth, f1, ext] = fileparts(to_check{iFile, 1});
+
+    % ugly but needed in case of compressed files (double extentions)
+    [f1, ext1] = split_extention(f1);
+    ext1 = [ext1, ext];
+    [base1, suffix1] = split_suffix(f1);
+    
+    for iData = 2:size(to_check, 2)
+      [pth, f2, ext] = fileparts(to_check{iFile, iData});
+      [f2, ext2] = split_extention(f2);
+      ext2 = [ext2, ext];
+      [base2, suffix2] = split_suffix(f2);
+
+      if ~allow_duplicates
+        if strcmp(f1, f2) && strcmp(ext1, ext2)
+          msg = sprintf('File %s (%d, %d) duplicates file %s (%d, %d)',...
+                        f1, iFile, 1,...
+                        f2, iFile, iData);
+          error(msg);
+        end
+      end
+
+      if ~strcmp(base1, base2)
+        msg = sprintf('File %s (%d, %d) mismatch file %s (%d, %d)',...
+                      f1, iFile, 1,...
+                      f2, iFile, iData);
+        error(msg);
+      end
+
+      if same_suffix && ~strcmp(suffix1, suffix2)
+        msg = sprintf('File %s (%d, %d) mismatch suffix file %s (%d, %d)',...
+                      f1, iFile, 1,...
+                      f2, iFile, iData);
+        error(msg);
+      end
+
+      if same_extention && ~strcmp(ext1, ext2)
+        msg = sprintf('File %s (%d, %d) mismatch extention file %s (%d, %d)',...
+                      f1, iFile, 1,...
+                      f2, iFile, iData);
+        error(msg);
+      end
+    end
+  end
+
+end
+
+function [basename, suffix] = split_suffix(fname)
+  basename = fname;
+  suffix = '';
+
+  pos = strfind(fname, '_');
+  if isempty(pos)
+    return
+  end
+
+  basename = fname(1:pos(end) - 1);
+  suffix = fname(pos(end): end);
+end
+
+function [basename, ext] = split_extention(fname)
+  basename = fname;
+  ext = '';
+
+  pos = strfind(fname, '.');
+  if isempty(pos)
+    return
+  end
+
+  basename = fname(1:pos(1) - 1);
+  ext = fname(pos(1): end);
+end

--- a/+bids/+util/check_data_consistency.m
+++ b/+bids/+util/check_data_consistency.m
@@ -1,4 +1,4 @@
-function check_data_consistency(to_check, varargin)
+function pass = check_data_consistency(to_check, varargin)
   %
   % Given a set of filepaths cellarrays from bids.query, checks that any
   % all paths at same index have consistent bids name and same size
@@ -7,7 +7,7 @@ function check_data_consistency(to_check, varargin)
   % Options:
   %   allow_duplicates  -- if set, will allow duplicated filenames
   %   same_suffix -- if set, files must have same suffix
-  %   same_extention -- if set, files must have same extention
+  %   same_extension -- if set, files must have same extention
   %
   % USAGE::
   %
@@ -28,12 +28,15 @@ function check_data_consistency(to_check, varargin)
   %% Validate input arguments
   % ==========================================================================
 
+  pass = true;
+
   allow_duplicates = false;
   same_suffix = false;
-  same_extention = false;
+  same_extension = false;
 
   if isempty(to_check)
-    error('No data selected');
+    pass = false;
+    error('MATLAB:emptyStructure', 'No data selected');
   end
 
   for ii = 1:size(varargin, 1)
@@ -41,10 +44,11 @@ function check_data_consistency(to_check, varargin)
       allow_duplicates = true;
     elseif strcmp(varargin{ii}, 'same_suffix')
       same_suffix = true;
-    elseif strcmp(varargin{ii}, 'same_extention')
-      same_extention = true;
+    elseif strcmp(varargin{ii}, 'same_extension')
+      same_extension = true;
     else 
-      error(['Unrecognised option ' varargin{ii}]);
+      pass = false;
+      error('MATLAB:invalidArgument', ['Unrecognised option ' varargin{ii}]);
     end
   end
 
@@ -64,32 +68,36 @@ function check_data_consistency(to_check, varargin)
 
       if ~allow_duplicates
         if strcmp(f1, f2) && strcmp(ext1, ext2)
+          pass = false;
           msg = sprintf('File %s (%d, %d) duplicates file %s (%d, %d)',...
                         f1, iFile, 1,...
                         f2, iFile, iData);
-          error(msg);
+          error('BIDS:duplicatedFile', msg);
         end
       end
 
       if ~strcmp(base1, base2)
+        pass = false;
         msg = sprintf('File %s (%d, %d) mismatch file %s (%d, %d)',...
                       f1, iFile, 1,...
                       f2, iFile, iData);
-        error(msg);
+        error('BIDS:invalidEntity', msg);
       end
 
       if same_suffix && ~strcmp(suffix1, suffix2)
+        pass = false;
         msg = sprintf('File %s (%d, %d) mismatch suffix file %s (%d, %d)',...
                       f1, iFile, 1,...
                       f2, iFile, iData);
-        error(msg);
+        error('BIDS:invalidSuffix', msg);
       end
 
-      if same_extention && ~strcmp(ext1, ext2)
-        msg = sprintf('File %s (%d, %d) mismatch extention file %s (%d, %d)',...
+      if same_extension && ~strcmp(ext1, ext2)
+        pass = false;
+        msg = sprintf('File %s (%d, %d) mismatch extension file %s (%d, %d)',...
                       f1, iFile, 1,...
                       f2, iFile, iData);
-        error(msg);
+        error('BIDS:invalidExtension', msg);
       end
     end
   end

--- a/tests/sub-01_task-STRUCTURE_events.tsv
+++ b/tests/sub-01_task-STRUCTURE_events.tsv
@@ -1,3 +1,3 @@
 onset	trial_type	duration	speed	is_fixation
-2	motion_up	1	n/a	1
-n/a	static	4	n/a	3
+2	motion_up	1	n/a	true
+n/a	static	4	4	3

--- a/tests/test_check_data_consistency.m
+++ b/tests/test_check_data_consistency.m
@@ -1,0 +1,55 @@
+function test_suite = test_check_data_consistency()
+    % This top function is necessary for mox unit to run tests.
+    % DO NOT CHANGE IT except to adapt the name of the function.
+    try % assignment of 'localfunctions' is necessary in Matlab >= 2016
+        test_functions = localfunctions(); %#ok<*NASGU>
+    catch % no problem; early Matlab versions can use initTestSuite fine
+    end
+    initTestSuite;
+end
+
+function test_function_to_test_basic()
+
+    % empty entry
+    assertExceptionThrown(@()bids.util.check_data_consistency([]), 'MATLAB:emptyStructure');
+
+    % invalid option
+    assertExceptionThrown(@()bids.util.check_data_consistency({'x'}, 'xxxx'),...
+                          'MATLAB:invalidArgument');
+
+    %% data to test against
+    flist_1 = {'sub-001_acq-X_run-01_BOLD.nii.gz'; 'sub-001_acq-X_run-02_BOLD.nii.gz'};
+    flist_2 = {'sub-001_acq-X_run-01_events.tsv'; 'sub-001_acq-X_run-02_events.tsv'};
+    flist_3 = {'sub-001_acq-X_run-01_dwi.nii.gz'; 'sub-001_acq-X_run-02_dwi.nii.gz'};
+    flist_4 = {'sub-001_acq-X_run-01_dwi.bval'; 'sub-001_acq-X_run-02_dwi.bval'};
+    flist_5 = {'sub-001_acq-Y_run-01_BOLD.nii.gz'; 'sub-001_acq-Y_run-02_BOLD.nii.gz'};
+
+    % succesful run
+    assertTrue(bids.util.check_data_consistency([flist_1, flist_2]));
+    assertExceptionThrown(@()bids.util.check_data_consistency([flist_1, flist_5]), ...
+                          'BIDS:invalidEntity');
+
+    % duplicated files
+    assertExceptionThrown(@()bids.util.check_data_consistency([flist_1, flist_1]),...
+                          'BIDS:duplicatedFile');
+    assertTrue(bids.util.check_data_consistency([flist_1, flist_1], 'allow_duplicates'));
+
+    % same suffix
+    assertTrue(bids.util.check_data_consistency([flist_3, flist_4],...
+                                                'same_suffix'));
+    assertExceptionThrown(@()bids.util.check_data_consistency([flist_1, flist_3],...
+                                                              'same_suffix'),...
+                          'BIDS:invalidSuffix');
+                        
+    % same extension
+    assertTrue(bids.util.check_data_consistency([flist_1, flist_3],...
+                                                'same_extension'));
+    assertExceptionThrown(@()bids.util.check_data_consistency([flist_3, flist_4],...
+                                                              'same_extension'),...
+                          'BIDS:invalidExtension');
+
+    % empty suffix
+    flist_1 = {'sub-001.nii.gz'; 'sub-001.nii.gz'};
+    flist_2 = {'sub-001.tsv'; 'sub-001.tsv'};
+    assertTrue(bids.util.check_data_consistency([flist_1, flist_2]));
+end


### PR DESCRIPTION
Added new function to util with main goal to check if data returned from different bids.query are consistent, i.e. has same name (up to suffix).

Probably not the most optimal way to implement.

- [x] tests
- [ ] documentation (have no idea how encode option as switches)