### PR TITLE
add split entity to meg files

### DIFF
--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -711,7 +711,7 @@ function entities = return_entities(modality)
       entities = {'sub', 'ses', 'task', 'acq', 'run', 'meta'};
 
     case 'meg'
-      entities = {'sub', 'ses', 'task', 'acq', 'run', 'proc', 'meta'};
+      entities = {'sub', 'ses', 'task', 'split', 'acq', 'run', 'proc', 'meta'};
 
     case 'beh'
       entities = {'sub', 'ses', 'task'};


### PR DESCRIPTION
When raw files are too big (>2GB), they are split at acquisition.
Previously,  split files crashed BIDS.layout with following error:

```
Warning: Ignoring file 'sub-Paris_ses-201811270935SOMALS2_task-EmptyRoom_split-01_meg.fif' not matching
template. 
> In bids.internal.parse_filename (line 53)
  In bids.layout>append_to_structure (line 668)
  In bids.layout>parse_meg (line 505)
  In bids.layout>parse_subject (line 193)
  In bids.layout (line 153)
  In e_setup (line 16) 
Array indices must be positive integers or logical values.
Error in bids.layout>parse_meg (line 507)
      subject.meg(end).meta = struct([]); % ?
Error in bids.layout>parse_subject (line 193)
  subject = parse_meg(subject);
Error in bids.layout (line 153)
        BIDS.subjects(end + 1) = parse_subject(BIDS.dir, sub{iSub}, sess{iSess});
Error in e_setup (line 16)
BIDS = bids.layout(dir_bids); 
```


https://bids-specification.readthedocs.io/en/stable/99-appendices/09-entities.html#split