### PR TITLE
[FIX] ensures that metadata file have the same prefix as the queried file

### DIFF
--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -22,10 +22,7 @@ function meta = get_metadata(filename, pattern)
   % assume most files are of the form *_suffix.json
   % add an exception for files with no suffix, like participants.tsv
   if nargin == 1
-    pattern = '^.*_%s\\.json$';
-    if ~ismember('_', filename)
-        pattern = '^.*%s\\.json$';
-    end
+    pattern = '^.*_?%s\\.json$';
   end
 
   pth = fileparts(filename);
@@ -64,9 +61,14 @@ function meta = get_metadata(filename, pattern)
         entities = fieldnames(p2.entities);
       end
 
-      % -Check if this metadata file contains the same entity-label pairs as its
-      % data file counterpart
+      % Check if this metadata file contains 
+      %   - the same entity-label pairs 
+      %   - same prefix
+      % as its data file counterpart
       ismeta = true;
+      if ~strcmp(p.suffix, p2.suffix)
+          ismeta = false;
+      end
       for j = 1:numel(entities)
         if ~isfield(p.entities, entities{j}) || ...
                 ~strcmp(p.entities.(entities{j}), p2.entities.(entities{j}))

--- a/tests/test_get_metadata.m
+++ b/tests/test_get_metadata.m
@@ -40,20 +40,33 @@ function test_get_metadata_basic()
 
   %% test func metadata base directory
   metadata = bids.query(BIDS, 'metadata', 'suffix', 'bold');
-  % assert(metadata.RepetitionTime == func.RepetitionTime);
+%   assert(metadata.RepetitionTime == func.RepetitionTime);
 
   %% test func metadata subject 01
   metadata = bids.query(BIDS, 'metadata', 'sub', '01', 'suffix', 'bold');
-  % assert(metadata.RepetitionTime == func_sub_01.RepetitionTime);
+  assert(metadata.RepetitionTime == func_sub_01.RepetitionTime);
 
   %% test anat metadata base directory
   metadata = bids.query(BIDS, 'metadata', 'suffix', 'T1w');
-  % assert(metadata.FlipAngle == anat.FlipAngle);
+%   assert(metadata.FlipAngle == anat.FlipAngle);
 
   %% test anat metadata subject 01
   metadata = bids.query(BIDS, 'metadata', 'sub', '01', 'suffix', 'T1w');
   assertEqual(metadata.FlipAngle, anat_sub_01.FlipAngle);
   assertEqual(metadata.Manufacturer, anat_sub_01.Manufacturer);
+
+end
+
+function test_get_metadata_participants()
+  % test files with no underscore in name.
+
+  pth_bids_example = get_test_data_dir();
+
+  file = fullfile(pth_bids_example, 'ds001', 'participants.tsv');
+  side_car = fullfile(pth_bids_example, 'ds001', 'participants.json');
+  metadata = bids.internal.get_metadata(file);
+  expected_metadata = bids.util.jsondecode(side_car);
+  assertEqual(metadata, expected_metadata);
 
 end
 

--- a/tests/test_get_metadata_suffixes.m
+++ b/tests/test_get_metadata_suffixes.m
@@ -30,16 +30,3 @@ function test_get_metadata_suffixes_basic()
   assertEqual(metadata, expected_metadata);
 
 end
-
-function test_get_metadata_participants()
-  % test files with no underscore in name.
-
-  pth_bids_example = get_test_data_dir();
-
-  file = fullfile(pth_bids_example, 'ds001', 'participants.tsv');
-  side_car = fullfile(pth_bids_example, 'ds001', 'participants.json');
-  metadata = bids.internal.get_metadata(file);
-  expected_metadata = bids.util.jsondecode(side_car);
-  assertEqual(metadata, expected_metadata);
-
-end


### PR DESCRIPTION
Fixes the issue of querying file with metadata files in the root directory (hence sometimes with no "_" before the suffix, like `T1w.json`) while still being able to query files with suffixes that might be part of another suffix: `_thickness.json` and `midthickness.json`. 