### PR TITLE
[FIX] return empty output of append to layout when failing to parse using schema

### DIFF
--- a/+bids/+internal/append_to_layout.m
+++ b/+bids/+internal/append_to_layout.m
@@ -33,6 +33,7 @@ function [subject, p] = append_to_layout(file, subject, modality, schema)
     if isempty(idx)
       warning('append_to_structure:noMatchingSuffix', ...
               'Skipping file with no valid suffix in schema: %s', file);
+      p = [];
       return
     end
 

--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -217,7 +217,7 @@ function copy_with_symlink(src, target)
 end
 
 function copy_dependencies(file, BIDS, derivatives_folder, unzip, force, skip_dep, verbose)
-    
+
   if ~skip_dep
 
     dependencies = fieldnames(file.dependencies);
@@ -238,7 +238,7 @@ function copy_dependencies(file, BIDS, derivatives_folder, unzip, force, skip_de
     end
 
   end
-  
+
 end
 
 function unzip_data(file, out_dir, unzip)

--- a/tests/test_parse_filename.m
+++ b/tests/test_parse_filename.m
@@ -21,10 +21,10 @@ function test_parse_filename_prefix()
                                        'run', '1'));
 
   assertEqual(output, expected);
-  
+
   expectedEntities = fieldnames(expected.entities);
   entities = fieldnames(output.entities);
-  assertEqual(entities, expectedEntities)    
+  assertEqual(entities, expectedEntities);
 
 end
 
@@ -44,10 +44,10 @@ function test_parse_filename_basic()
                     'prefix', '');
 
   assertEqual(output, expected);
-  
+
   expectedEntities = fieldnames(expected.entities);
   entities = fieldnames(output.entities);
-  assertEqual(entities, expectedEntities)  
+  assertEqual(entities, expectedEntities);
 
 end
 
@@ -69,10 +69,10 @@ function test_parse_filename_fields()
                     'prefix', '');
 
   assertEqual(output, expected);
-  
+
   expectedEntities = fieldnames(expected.entities);
   entities = fieldnames(output.entities);
-  assertEqual(entities, expectedEntities)
+  assertEqual(entities, expectedEntities);
 
 end
 


### PR DESCRIPTION
that can lead to weird bugs and associates the wrong metadata with certain files