### PR TITLE
[INFRA] add copyright checks from miss_hit

### DIFF
--- a/+bids/+internal/README.md
+++ b/+bids/+internal/README.md
@@ -1,6 +1,7 @@
-BIDS-MATLAB +internal package
-=============================
+# BIDS-MATLAB +internal package
 
 This package contains functions for BIDS-MATLAB's internal use only.
 
-Do not call these functions directly from your code! They are undocumented and subject to change at any time. If you call these functions from your code, your code may break or produce incorrect results!
+Do not call these functions directly from your code! They are undocumented and
+subject to change at any time.
+If you call these functions from your code, your code may break or produce incorrect results!

--- a/+bids/+internal/add_missing_field.m
+++ b/+bids/+internal/add_missing_field.m
@@ -1,4 +1,8 @@
 function structure = add_missing_field(structure, field)
+  %
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
+
   if ~isfield(structure, field)
     structure(1).(field) = '';
   end

--- a/+bids/+internal/append_to_layout.m
+++ b/+bids/+internal/append_to_layout.m
@@ -16,7 +16,7 @@ function [subject, p] = append_to_layout(file, subject, modality, schema)
   % :type  schema: strcture
   %
   %
-  % Copyright (C) 2021--, BIDS-MATLAB developers
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   if ~exist('schema', 'var')
     schema = [];

--- a/+bids/+internal/ends_with.m
+++ b/+bids/+internal/ends_with.m
@@ -2,17 +2,19 @@ function res = ends_with(str, pattern)
   %
   % Checks id character array 'str' ends with 'pat'
   %
-  % USAGE  res = bids.internal.endsWith(str, pat)
+  % USAGE::
+  %         res = bids.internal.endsWith(str, pat)
   %
   % str        - character array
   % pat        - character array
   %
   % __________________________________________________________________________
   %
-  % Based on spm_file.m and spm_select.m from SPM12.
+  % Based on the equivalent function from SPM12
   % __________________________________________________________________________
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
-  % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   res = false;
   l_pat = length(pattern);
   if l_pat > length(str)

--- a/+bids/+internal/file_utils.m
+++ b/+bids/+internal/file_utils.m
@@ -2,19 +2,19 @@ function varargout = file_utils(str, varargin)
   %
   % Character array (or cell array of strings) handling facility
   %
+  % USAGE:
   %
-  % To list files or directories (with fullpath if necessary)
+  % To list files or directories (with fullpath if necessary)::
   %
-  % FORMAT [files, dirs] = bids.internal.file_utils('List',   directory,        regexp)
-  % FORMAT [files, dirs] = bids.internal.file_utils('FPList', directory,        regexp)
-  % FORMAT [dirs]        = bids.internal.file_utils('List',   directory, 'dir', regexp)
-  % FORMAT [dirs]        = bids.internal.file_utils('FPList', directory, 'dir', regexp)
+  %   [files, dirs] = bids.internal.file_utils('List',   directory,        regexp)
+  %   [files, dirs] = bids.internal.file_utils('FPList', directory,        regexp)
+  %   [dirs]        = bids.internal.file_utils('List',   directory, 'dir', regexp)
+  %   [dirs]        = bids.internal.file_utils('FPList', directory, 'dir', regexp)
   %
   %
+  % To get a certain piece of information from a file::
   %
-  % To get a certain piece of information from a file.
-  %
-  % FORMAT str = bids.internal.file_utils(str, option)
+  %   str = bids.internal.file_utils(str, option)
   %
   % str        - character array, or cell array of strings
   %
@@ -22,10 +22,9 @@ function varargout = file_utils(str, varargin)
   %              {'path', 'basename', 'ext', 'filename', 'cpath', 'fpath'}
   %
   %
+  % To set a certain piece of information from a file::
   %
-  % To set a certain piece of information from a file.
-  %
-  % FORMAT str = bids.internal.file_utils(str, opt_key, opt_val,...)
+  %   str = bids.internal.file_utils(str, opt_key, opt_val, ...)
   %
   % str        - character array, or cell array of strings
   %
@@ -38,8 +37,8 @@ function varargout = file_utils(str, varargin)
   %
   % Based on spm_file.m and spm_select.m from SPM12.
   % __________________________________________________________________________
-
-  % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   %#ok<*AGROW>
 

--- a/+bids/+internal/get_meta_list.m
+++ b/+bids/+internal/get_meta_list.m
@@ -14,10 +14,10 @@ function metalist = get_meta_list(filename, pattern)
   %
   %
   % metalist    - list of paths to metafiles
-  % __________________________________________________________________________
-
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  %
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   if nargin == 1
     pattern = '^.*%s\\.json$';

--- a/+bids/+internal/get_metadata.m
+++ b/+bids/+internal/get_metadata.m
@@ -14,10 +14,10 @@ function meta = get_metadata(metafile)
   % .. todo
   %
   %    add explanation on how the inheritance principle is implemented.
-  % __________________________________________________________________________
-
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  %
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   meta = struct();
   metafile = cellstr(metafile);

--- a/+bids/+internal/keep_file_for_query.m
+++ b/+bids/+internal/keep_file_for_query.m
@@ -1,4 +1,7 @@
 function status = keep_file_for_query(file_struct, options)
+  %
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   status = true;
 

--- a/+bids/+internal/match_structure_fields.m
+++ b/+bids/+internal/match_structure_fields.m
@@ -1,4 +1,13 @@
 function [s1, s2] = match_structure_fields(s1, s2)
+  %
+  % Update field content of a structure so it matches that of another.
+  %
+  % USAGE::
+  %
+  %   [s1, s2] = match_structure_fields(s1, s2)
+  %
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   missing_fields = setxor(fieldnames(s1), fieldnames(s2));
 

--- a/+bids/+internal/parse_filename.m
+++ b/+bids/+internal/parse_filename.m
@@ -30,10 +30,9 @@ function p = parse_filename(filename, fields)
   %                        'run', '1', ...
   %                        'acq', 'hd');
   %
-  % __________________________________________________________________________
-
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   fields_order = {'filename', 'ext', 'suffix', 'entities', 'prefix'};
 

--- a/+bids/+internal/return_file_index.m
+++ b/+bids/+internal/return_file_index.m
@@ -3,8 +3,7 @@ function file_idx = return_file_index(BIDS, modality, filename)
   % For a given filename and modality, it returns the file index
   % in the subject sub-structure of the BIDS structure
   %
-
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   sub_idx = bids.internal.return_subject_index(BIDS, filename);
 

--- a/+bids/+internal/return_file_info.m
+++ b/+bids/+internal/return_file_info.m
@@ -1,4 +1,6 @@
 function file_info = return_file_info(BIDS, fullpath_filename)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   file_info.path = bids.internal.file_utils(fullpath_filename, 'path');
   file_info.modality = bids.internal.file_utils(file_info.path, 'filename');

--- a/+bids/+internal/return_modality_extensions.m
+++ b/+bids/+internal/return_modality_extensions.m
@@ -1,4 +1,6 @@
 function extensions = return_modality_extensions(modality)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   extensions = '(';
 

--- a/+bids/+internal/return_modality_regular_expression.m
+++ b/+bids/+internal/return_modality_regular_expression.m
@@ -1,4 +1,6 @@
 function regular_expression = return_modality_regular_expression(modality)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   suffixes = bids.internal.return_modality_suffixes(modality);
   extensions = bids.internal.return_modality_extensions(modality);

--- a/+bids/+internal/return_modality_suffixes.m
+++ b/+bids/+internal/return_modality_suffixes.m
@@ -1,4 +1,6 @@
 function suffixes = return_modality_suffixes(modality)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   suffixes = '_(';
 

--- a/+bids/+internal/return_subject_index.m
+++ b/+bids/+internal/return_subject_index.m
@@ -4,8 +4,7 @@ function sub_idx = return_subject_index(BIDS, filename)
   % that: ``BIDS.subjects(sub_idx)``
   %
   %
-
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   parsed_file = bids.internal.parse_filename(filename);
   sub = parsed_file.entities.sub;

--- a/+bids/+internal/starts_with.m
+++ b/+bids/+internal/starts_with.m
@@ -2,17 +2,20 @@ function res = starts_with(str, pattern)
   %
   % Checks id character array 'str' starts with 'pat'
   %
-  % USAGE  res = bids.internal.startsWith(str, pat)
+  % USAGE::
+  %
+  %   res = bids.internal.startsWith(str, pat)
   %
   % str        - character array
   % pat        - character array
   %
   % __________________________________________________________________________
   %
-  % Based on spm_file.m and spm_select.m from SPM12.
+  % Based on the equivalent function from SPM12.
   % __________________________________________________________________________
+  % (C) Copyright 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
-  % Copyright (C) 2011-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
   res = false;
   l_pat = length(pattern);
   if l_pat > length(str)

--- a/+bids/+schema/load_schema.m
+++ b/+bids/+schema/load_schema.m
@@ -5,7 +5,7 @@ function schema = load_schema(use_schema)
   % any eventual nesting within each json.
   %
   %
-  % Copyright (C) 2021--, BIDS-MATLAB developers
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   % TODO:
   %  - folders that do not contain json files themselves but contain

--- a/+bids/+schema/return_modalities.m
+++ b/+bids/+schema/return_modalities.m
@@ -1,4 +1,6 @@
 function modalities = return_modalities(subject, schema, modality_group)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   % if we go schema-less we list directories in the subject/session folder
   % as proxy of the modalities that we have to parse

--- a/+bids/+schema/return_modality_entities.m
+++ b/+bids/+schema/return_modality_entities.m
@@ -1,4 +1,6 @@
 function entities = return_modality_entities(suffix_group, schema)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   % for CI
   if iscell(suffix_group)

--- a/+bids/+schema/return_modality_groups.m
+++ b/+bids/+schema/return_modality_groups.m
@@ -1,4 +1,6 @@
 function modality_groups = return_modality_groups(schema)
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   % dummy variable if we go schema less
   modality_groups = {nan()};

--- a/+bids/+util/jsondecode.m
+++ b/+bids/+util/jsondecode.m
@@ -19,9 +19,9 @@ function value = jsondecode(file, varargin)
   %
   % :returns: - :json: JSON structure
   %
-
-  % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   persistent has_jsondecode
   if isempty(has_jsondecode)

--- a/+bids/+util/jsonencode.m
+++ b/+bids/+util/jsonencode.m
@@ -31,9 +31,9 @@ function varargout = jsonencode(varargin)
   %                    [Default: ``true``]
   % :type opts: structure  -
   %
-
-  % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   if ~nargin
     error('Not enough input arguments.');

--- a/+bids/+util/tsvread.m
+++ b/+bids/+util/tsvread.m
@@ -7,14 +7,13 @@ function fileContent = tsvread(filename, fieldToReturn, hdr)
   % hdr - detect the presence of a header row for csv/tsv [default: true]
   %
   % x - corresponding data array or structure
-
+  %
   % __________________________________________________________________________
   %
   % Based on spm_load.m from SPM12.
   % __________________________________________________________________________
-
-  % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  % (C) Copyright 2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   % -Check input arguments
   % --------------------------------------------------------------------------

--- a/+bids/+util/tsvwrite.m
+++ b/+bids/+util/tsvwrite.m
@@ -4,10 +4,12 @@ function tsvwrite(f, var)
   % f     - filename
   % var   - data array or structure
   %
-  % Adapted from spm_save.m
   % __________________________________________________________________________
-  % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % Based on spm_save.m from SPM12.
+  % __________________________________________________________________________
+  % (C) Copyright 2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   delim = sprintf('\t');
 

--- a/+bids/Contents.m
+++ b/+bids/Contents.m
@@ -10,6 +10,13 @@
 %   util.jsonencode - Encode JSON-formatted file
 %   util.tsvread    - Load text and numeric data from tab-separated-value file
 %   util.tsvwrite   - Save text and numeric data to tab-separated-value file
+%
+% __________________________________________________________________________
+%
+% BIDS-MATLAB is a library that aims at centralising MATLAB/Octave tools
+% for interacting with datasets conforming to the BIDS format.
+% See https://github.com/bids-standard/bids-matlab for more details.
+%
 % __________________________________________________________________________
 %
 % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
@@ -18,6 +25,5 @@
 %   K. J. Gorgolewski et al, Scientific Data, 2016.
 % __________________________________________________________________________
 %
-% BIDS-MATLAB is a library that aims at centralising MATLAB/Octave tools
-% for interacting with datasets conforming to the BIDS format.
-% See https://github.com/bids-standard/bids-matlab for more details.
+% (C) Copyright 2016-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+% (C) Copyright 2018 BIDS-MATLAB developers

--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -31,9 +31,8 @@ function copy_to_derivative(BIDS, out_path, pipeline_name, filter, unzip, force,
   %   describing outputs of neuroimaging experiments.
   %   K. J. Gorgolewski et al, Scientific Data, 2016.
   % __________________________________________________________________________
-
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2021--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2021 BIDS-MATLAB developers
 
   narginchk(2, Inf);
 

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -17,7 +17,6 @@ function BIDS = layout(root, use_schema)
   % :type  use_schema: boolean
   %
   %
-
   % __________________________________________________________________________
   %
   % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
@@ -26,8 +25,8 @@ function BIDS = layout(root, use_schema)
   %   K. J. Gorgolewski et al, Scientific Data, 2016.
   % __________________________________________________________________________
   %
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  % (C) Copyright 2016-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   %% Validate input arguments
   % ==========================================================================

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -40,6 +40,7 @@ function result = query(BIDS, query, varargin)
   %
   %     data = bids.query(BIDS, 'data', filters);
   %
+  %
   % __________________________________________________________________________
   %
   % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
@@ -47,9 +48,9 @@ function result = query(BIDS, query, varargin)
   %   describing outputs of neuroimaging experiments.
   %   K. J. Gorgolewski et al, Scientific Data, 2016.
   % __________________________________________________________________________
-
-  % Copyright (C) 2016-2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2016-2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   %#ok<*AGROW>
   narginchk(2, Inf);

--- a/+bids/report.m
+++ b/+bids/report.m
@@ -1,6 +1,9 @@
 function report(BIDS, Subj, Ses, Run, ReadNII)
   % Create a short summary of the acquisition parameters of a BIDS dataset
-  % FORMAT bids.report(BIDS, Subj, Ses, Run, ReadNII)
+  %
+  % USAGE::
+  %
+  %   bids.report(BIDS, Subj, Ses, Run, ReadNII)
   %
   % INPUTS:
   % - BIDS: directory formatted according to BIDS [Default: pwd]
@@ -19,7 +22,8 @@ function report(BIDS, Subj, Ses, Run, ReadNII)
   %
   % See also:
   % bids
-
+  %
+  %
   % __________________________________________________________________________
   %
   % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
@@ -27,9 +31,9 @@ function report(BIDS, Subj, Ses, Run, ReadNII)
   %   describing outputs of neuroimaging experiments.
   %   K. J. Gorgolewski et al, Scientific Data, 2016.
   % __________________________________________________________________________
-
-  % Copyright (C) 2018, Remi Gau
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  % (C) Copyright 2018 Remi Gau
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   % TODO
   % --------------------------------------------------------------------------

--- a/+bids/validate.m
+++ b/+bids/validate.m
@@ -1,6 +1,10 @@
 function [sts, msg] = validate(root)
   % BIDS Validator
-  % FORMAT [sts, msg] = bids.validate(root)
+  %
+  % USAGE::
+  %
+  %         [sts, msg] = bids.validate(root)
+  %
   % root    - directory formatted according to BIDS [Default: pwd]
   % sts     - 0 if successful
   % msg     - warning and error messages
@@ -15,9 +19,18 @@ function [sts, msg] = validate(root)
   %
   % See also:
   % bids
-
-  % Copyright (C) 2018, Guillaume Flandin, Wellcome Centre for Human Neuroimaging
-  % Copyright (C) 2018--, BIDS-MATLAB developers
+  %
+  %
+  % __________________________________________________________________________
+  %
+  % BIDS (Brain Imaging Data Structure): https://bids.neuroimaging.io/
+  %   The brain imaging data structure, a format for organizing and
+  %   describing outputs of neuroimaging experiments.
+  %   K. J. Gorgolewski et al, Scientific Data, 2016.
+  % __________________________________________________________________________
+  %
+  % (C) Copyright 2018 Guillaume Flandin, Wellcome Centre for Human Neuroimaging
+  % (C) Copyright 2018 BIDS-MATLAB developers
 
   [sts, ~] = system('bids-validator --version');
   if sts

--- a/miss_hit.cfg
+++ b/miss_hit.cfg
@@ -5,15 +5,10 @@ project_root
 # rules that we do not apply
 suppress_rule: "naming_functions"
 suppress_rule: "naming_classes"
-suppress_rule: "copyright_notice"
 
-# directories to ignore
-# for the moment we do not lint source code
-# exclude_dir: "+bids"
-
-# if we decide to use the copyright_notice rule uncomment the lines below
-# copyright_entity: "Guillaume Flandin, Wellcome Centre for Human Neuroimaging"
-# copyright_entity: "BIDS-MATLAB developers"
+copyright_entity: "Guillaume Flandin, Wellcome Centre for Human Neuroimaging"
+copyright_entity: "Remi Gau"
+copyright_entity: "BIDS-MATLAB developers"
 
 # function and class names: based on regular expressions
 # not implemented yet

--- a/tests/miss_hit.cfg
+++ b/tests/miss_hit.cfg
@@ -1,3 +1,5 @@
 # style guide (https://florianschanda.github.io/miss_hit/style_checker.html)
 
 exclude_dir: "bids-examples"
+
+suppress_rule: "copyright_notice"


### PR DESCRIPTION
Miss hit now allows for copyright notice to be at the end of a help section.

This fits more with the way we have been keeping track of that so far, so we can implement that now.