### PR TITLE
FIX: Update pattern expression for pet to capture data without task label

### DIFF
--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -788,7 +788,7 @@ function file_list = return_file_list(modality, subject)
       pattern = '_([a-zA-Z0-9]+){1}\\.nii(\\.gz)?';
 
     case 'pet'
-      pattern = '_task-.*_pet\\.nii(\\.gz)?';
+      pattern = '_pet\\.nii(\\.gz)?';
 
     case 'ieeg'
       pattern = '_task-.*_ieeg\\..*[^json]';


### PR DESCRIPTION
This PR updates the pattern expression in layout.m to parse PET data without a task label. The problem was described in https://github.com/bids-standard/bids-matlab/issues/233#issue-903878024. 