### PR TITLE
Fixed bug of copying_to_derivative using structure

### DIFF
--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -34,22 +34,19 @@ function BIDS = layout(root, use_schema)
   if ~nargin
     root = pwd;
 
-  elseif nargin == 1
-
-    if ischar(root)
-      root = bids.internal.file_utils(root, 'CPath');
-
-    elseif isstruct(root)
-      BIDS = root; % for bids.query
-      return
-
-    else
-      error('Invalid syntax.');
-
-    end
-
   elseif nargin > 2
     error('Too many input arguments.');
+  end
+
+  if ischar(root)
+    root = bids.internal.file_utils(root, 'CPath');
+
+  elseif isstruct(root)
+    BIDS = root; % for bids.query
+    return
+
+  else
+    error('Invalid syntax.');
 
   end
 


### PR DESCRIPTION
There was a small bug in the argument parsing of `bids.layout`.

The check if `root` is structure was performed only if number of input arguments is 1, 
calling with optional parameter `use_schema` (like it is used in `copy_to_derivative`) 
skips this check and crashes on line
```matlab
if ~exist(root, 'dir')
```

This PR fixes it.