### PR TITLE
[FIX] enforce valid fieldnames in schema content and skip schema metadata loading by default

### DIFF
--- a/+bids/schema.m
+++ b/+bids/schema.m
@@ -8,6 +8,7 @@ classdef schema
     content
     verbose = false
     is_bids_schema = false
+    load_schema_metadata = false
   end
 
   %% PUBLIC
@@ -297,17 +298,24 @@ classdef schema
       % Recursively inspects subdirectory for json files and reflects folder
       % hierarchy in the output structure.
       %
+
       for iDir = 1:size(subdir_list, 1)
 
         directory = deblank(subdir_list(iDir, :));
 
-        [json_file_list, dirs] = bids.internal.file_utils('FPList', directory, '^.*.json$');
+        % skip loading json files about metadata unless asked for it
+        if obj.load_schema_metadata || ...
+                ~strcmp(bids.internal.file_utils(directory, 'basename'), 'metadata')
 
-        if ~isempty(json_file_list)
-          field_name = bids.internal.file_utils(directory, 'basename');
-          structure.(field_name) = struct();
-          structure.(field_name) = obj.append_json_to_schema(structure.(field_name), ...
-                                                             json_file_list);
+          [json_file_list, dirs] = bids.internal.file_utils('FPList', directory, '^.*.json$');
+
+          if ~isempty(json_file_list)
+            field_name = bids.internal.file_utils(directory, 'basename');
+            structure.(field_name) = struct();
+            structure.(field_name) = obj.append_json_to_schema(structure.(field_name), ...
+                                                               json_file_list);
+          end
+
         end
 
         structure = obj.inspect_subdir(obj, structure, dirs);

--- a/+bids/schema.m
+++ b/+bids/schema.m
@@ -272,7 +272,7 @@ classdef schema
   %% STATIC
   methods (Static)
 
-    %% Loading related methods
+    %% Methods related to schema loading
     function structure = append_json_to_schema(structure, json_file_list)
       %
       % Reads a json file and appends its content to the bids schema
@@ -280,7 +280,12 @@ classdef schema
       for iFile = 1:size(json_file_list, 1)
         file = deblank(json_file_list(iFile, :));
 
+        % use dynamic field name and converts to a valid matlab fieldname
         field_name = bids.internal.file_utils(file, 'basename');
+        field_name = strrep(field_name, '.', '_');
+        if strcmp(field_name(1), '_')
+          field_name(1) = [];
+        end
 
         structure.(field_name) = bids.util.jsondecode(file);
       end

--- a/tests/test_bids_schema.m
+++ b/tests/test_bids_schema.m
@@ -6,6 +6,20 @@ function test_suite = test_bids_schema %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_metadata_loading()
+
+  schema = bids.schema;
+  schema = schema.load();
+  assert(~isfield(schema.content, 'metadata'));
+
+  schema = bids.schema;
+  schema.load_schema_metadata = true;
+  schema = schema.load();
+  assert(isfield(schema.content, 'metadata'));
+  assert(isstruct(schema.content.metadata));
+
+end
+
 function test_return_required_entities
 
   schema = bids.schema();


### PR DESCRIPTION
The recent extension of the schema leads to:
- invalid matlab fieldnames in the schema content structure
- the loading of over 350 json files when loading the schema which can slow things down if the schema has to be loaded often

This PR:
- ensures that the fieldnames of the content structure are valid
  - this is a quick fix and only removes leading underscores and dots (`.`) in the middle of the fieldname
- skip metadata loading by default