### PR TITLE
[ENH] Index tsv and json files in root folder 

### DIFF
--- a/+bids/+internal/keep_file_for_query.m
+++ b/+bids/+internal/keep_file_for_query.m
@@ -21,7 +21,14 @@ function status = keep_file_for_query(file_struct, options)
     end
 
   end
+  
+    % some files in the root folder might have no entity 
+    if isempty(file_struct.entities)
+      status = false;
+      return
+    end
 
+  % work on the the entities
   for l = 1:size(options, 1)
 
     if ~any(strcmp(options{l, 1}, {'suffix', 'extension', 'prefix'}))

--- a/+bids/+internal/keep_file_for_query.m
+++ b/+bids/+internal/keep_file_for_query.m
@@ -21,12 +21,12 @@ function status = keep_file_for_query(file_struct, options)
     end
 
   end
-  
-    % some files in the root folder might have no entity 
-    if isempty(file_struct.entities)
-      status = false;
-      return
-    end
+
+  % some files in the root folder might have no entity
+  if isempty(file_struct.entities)
+    status = false;
+    return
+  end
 
   % work on the the entities
   for l = 1:size(options, 1)

--- a/+bids/+internal/return_file_info.m
+++ b/+bids/+internal/return_file_info.m
@@ -3,10 +3,15 @@ function file_info = return_file_info(BIDS, fullpath_filename)
   % (C) Copyright 2021 BIDS-MATLAB developers
 
   file_info.path = bids.internal.file_utils(fullpath_filename, 'path');
-  file_info.modality = bids.internal.file_utils(file_info.path, 'filename');
   file_info.filename = bids.internal.file_utils(fullpath_filename, 'filename');
 
   file_info.sub_idx = bids.internal.return_subject_index(BIDS, file_info.filename);
+  % for files in the root folder with no sub entity we return early
+  if isempty(file_info.sub_idx)
+    return
+  end
+
+  file_info.modality = bids.internal.file_utils(file_info.path, 'filename');
   file_info.file_idx = bids.internal.return_file_index(BIDS, ...
                                                        file_info.modality, ...
                                                        file_info.filename);

--- a/+bids/+internal/return_subject_index.m
+++ b/+bids/+internal/return_subject_index.m
@@ -7,6 +7,12 @@ function sub_idx = return_subject_index(BIDS, filename)
   % (C) Copyright 2021 BIDS-MATLAB developers
 
   parsed_file = bids.internal.parse_filename(filename);
+
+  % for files in the root folder with no sub entity we return immediately
+  if ~isfield(parsed_file, 'entities') || ~isfield(parsed_file.entities, 'sub')
+    sub_idx = [];
+    return
+  end
   sub = parsed_file.entities.sub;
 
   sub_idx = strcmp(['sub-' sub], {BIDS.subjects.name}');

--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -225,6 +225,12 @@ end
 function copy_file(BIDS, derivatives_folder, data_file, unzip_files, force, skip_dep, verbose)
 
   info = bids.internal.return_file_info(BIDS, data_file);
+
+  if ~isfield(info, 'sub_idx') || ~isfield(info, 'modality')
+    % TODO: for we do not copy files in the root directory that have been indexed.
+    return
+  end
+
   file = BIDS.subjects(info.sub_idx).(info.modality)(info.file_idx);
 
   out_dir = fullfile(derivatives_folder, ...

--- a/miss_hit.cfg
+++ b/miss_hit.cfg
@@ -26,5 +26,5 @@ tab_width: 2
 # metrics limit for the code quality (https://florianschanda.github.io/miss_hit/metrics.html)
 metric "cnest": limit 5
 metric "file_length": limit 700
-metric "cyc": limit 18
+metric "cyc": limit 17
 metric "parameters": limit 8

--- a/tests/test_bids_query.m
+++ b/tests/test_bids_query.m
@@ -6,6 +6,21 @@ function test_suite = test_bids_query %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_query_events_tsv_in_root()
+
+  pth_bids_example = get_test_data_dir();
+
+  BIDS = bids.layout(fullfile(pth_bids_example, 'synthetic'));
+
+  data = bids.query(BIDS, 'data', 'sub', '01', 'ses', '01', 'task', 'nback', 'suffix', 'events');
+
+  assertEqual(data, ...
+              {bids.internal.file_utils(fullfile(pth_bids_example, ...
+                                                 'synthetic', ...
+                                                 'task-nback_events.tsv'), 'cpath')});
+
+end
+
 function test_query_exclude_entity()
 
   pth_bids_example = get_test_data_dir();

--- a/tests/test_bids_query_eeg.m
+++ b/tests/test_bids_query_eeg.m
@@ -30,9 +30,8 @@ function test_bids_query_eeg_basic()
   modalities = {'anat', 'eeg'};
   assertEqual(bids.query(BIDS, 'modalities'), modalities);
 
-  suffixes = {'T1w', 'eeg', 'electrodes', 'events'};
-  % Missing: 'coordsystem',
-  % Missing: 'channels' in root folder
+  suffixes = {'T1w', 'channels', 'eeg', 'electrodes', 'events'};
+  % Missing: 'coordsystem'
   assertEqual(bids.query(BIDS, 'suffixes'), suffixes);
 
   %% dependencies

--- a/tests/test_keep_file.m
+++ b/tests/test_keep_file.m
@@ -65,3 +65,15 @@ function test_keep_file_exclude_entity()
   assertEqual(bids.internal.keep_file_for_query(file_struct, options), true);
 
 end
+
+function test_keep_file_events_in_root()
+
+  file_struct = struct('prefix', '', ...
+                       'suffix', 'events', ...
+                       'ext', '.tsv', ...
+                       'entities', struct('task', 'nback'));
+
+  options = {'sub', {'01'}};
+  assertEqual(bids.internal.keep_file_for_query(file_struct, options), false);
+
+end

--- a/tests/test_layout_derivatives.m
+++ b/tests/test_layout_derivatives.m
@@ -15,6 +15,7 @@ function test_layout_nested()
   index_derivatives = true;
 
   BIDS = bids.layout(fullfile(pth_bids_example, 'ds000117'), use_schema, index_derivatives);
+
 end
 
 function test_layout_meg_derivatives()


### PR DESCRIPTION
Fixes #64 and can now index events.tsv files put in the root folder but still does not index files that can still be put in the subject or session folder.

But this should already cover many datasets.

For the moment `genetic_info.json` file is not indexed because it does not play well `parse_filename`.