### PR TITLE
Improve bids.init

### DIFF
--- a/+bids/init.m
+++ b/+bids/init.m
@@ -38,21 +38,8 @@ function init(varargin)
 
   parse(p, varargin{:});
 
-  subjects =  p.Results.folders.subjects;
-  if ~iscell(subjects)
-    subjects = {subjects};
-  end
-  if ~isempty(p.Results.folders.subjects)
-    subjects = cellfun(@(x) ['sub-' x], p.Results.folders.subjects, 'UniformOutput', false);
-  end
-
-  sessions =  p.Results.folders.sessions;
-  if ~iscell(sessions)
-    sessions = {sessions};
-  end
-  if ~isempty(p.Results.folders.sessions)
-    sessions = cellfun(@(x) ['ses-' x], p.Results.folders.sessions, 'UniformOutput', false);
-  end
+  subjects = create_folder_names(p, 'subjects');
+  sessions = create_folder_names(p, 'sessions');
 
   %% Folder structure
   bids.util.mkdir(p.Results.pth, ...
@@ -80,5 +67,27 @@ function init(varargin)
   fprintf(file_id, '1.0.0 %s\n', datestr(now, 'yyyy-mm-dd'));
   fprintf(file_id, '- dataset creation.');
   fclose(file_id);
+
+end
+
+function folder_list = create_folder_names(p, folder_level)
+
+  folder_list =  p.Results.folders.(folder_level);
+  if ~iscell(folder_list)
+    folder_list = {folder_list};
+  end
+
+  switch folder_level
+    case 'subjects'
+      prefix = 'sub-';
+    case 'sessions'
+      prefix = 'ses-';
+  end
+
+  if ~isempty(p.Results.folders.(folder_level))
+    folder_list = cellfun(@(x) [prefix x], ...
+                          p.Results.folders.(folder_level), ...
+                          'UniformOutput', false);
+  end
 
 end

--- a/+bids/init.m
+++ b/+bids/init.m
@@ -38,10 +38,26 @@ function init(varargin)
 
   parse(p, varargin{:});
 
+  subjects =  p.Results.folders.subjects;
+  if ~iscell(subjects)
+    subjects = {subjects};
+  end
+  if ~isempty(p.Results.folders.subjects)
+    subjects = cellfun(@(x) ['sub-' x], p.Results.folders.subjects, 'UniformOutput', false);
+  end
+
+  sessions =  p.Results.folders.sessions;
+  if ~iscell(sessions)
+    sessions = {sessions};
+  end
+  if ~isempty(p.Results.folders.sessions)
+    sessions = cellfun(@(x) ['ses-' x], p.Results.folders.sessions, 'UniformOutput', false);
+  end
+
   %% Folder structure
   bids.util.mkdir(p.Results.pth, ...
-                  p.Results.folders.subjects, ...
-                  p.Results.folders.sessions, ...
+                  subjects, ...
+                  sessions, ...
                   p.Results.folders.modalities);
 
   %% README

--- a/tests/test_bids_init.m
+++ b/tests/test_bids_init.m
@@ -9,15 +9,63 @@ end
 
 function test_basic()
 
-  is_derivative = true;
-  is_datalad_ds = true;
-
-  folders.subjects = {'sub-01', 'sub-02'};
-  folders.sessions = {'ses-test', 'ses-retest'};
-  folders.modalities = {'anat', 'func'};
+  dataset_description = fullfile(pwd, 'dummy_ds', 'dataset_description.json');
 
   bids.init('dummy_ds');
+  assertEqual(exist(fullfile(pwd, 'dummy_ds'), 'dir'), 7);
+
+  assertEqual(exist(dataset_description, 'file'), 2);
+  ds_metadata = bids.util.jsondecode(dataset_description);
+  assertEqual(ds_metadata.DatasetType, 'raw');
+
+  cleanUp();
+
+end
+
+function test_folders()
+
+  folders.subjects = {'01', '02'};
+  folders.sessions = {'test', 'retest'};
+  folders.modalities = {'anat', 'func'};
+
+  bids.init('dummy_ds', folders);
+  assertEqual(exist(fullfile(pwd, 'dummy_ds', 'sub-02', 'ses-retest', 'func'), 'dir'), 7);
+
+  cleanUp();
+
+end
+
+function test_derivatives()
+
+  is_derivative = true;
+
+  folders.subjects = {'01', '02'};
+  folders.sessions = {'test', 'retest'};
+  folders.modalities = {'anat', 'func'};
+
+  dataset_description = fullfile(pwd, 'dummy_ds', 'dataset_description.json');
+
   bids.init('dummy_ds', folders, is_derivative);
+  assertEqual(exist(fullfile(pwd, 'dummy_ds', 'sub-02', 'ses-retest', 'func'), 'dir'), 7);
+
+  ds_metadata = bids.util.jsondecode(dataset_description);
+  assertEqual(ds_metadata.DatasetType, 'derivative');
+
+  % smoke test
+  is_datalad_ds = true;
   bids.init('dummy_ds', folders, is_derivative, is_datalad_ds);
+
+  cleanUp();
+
+end
+
+function cleanUp()
+
+  pause(1);
+
+  if is_octave()
+    confirm_recursive_rmdir (true, 'local');
+  end
+  rmdir(fullfile(pwd, 'dummy_ds'), 's');
 
 end

--- a/tests/utils/is_octave.m
+++ b/tests/utils/is_octave.m
@@ -1,0 +1,20 @@
+function status = is_octave()
+  %
+  % Returns true if the environment is Octave.
+  %
+  % USAGE::
+  %
+  %   status = isOctave()
+  %
+  % :returns: :status: (boolean)
+  %
+  % (C) Copyright 2020 Agah Karakuzu
+
+  persistent cacheval   % speeds up repeated calls
+
+  if isempty (cacheval)
+    cacheval = (exist ('OCTAVE_VERSION', 'builtin') > 0);
+  end
+
+  status = cacheval;
+end


### PR DESCRIPTION
Only subjects and sessions labels need to be passed as argument of bids.init for directory structure creation.

Old behavior required to pass the entity-label pairs.