### PR TITLE
[FIX] add warning when indexing folder with invalid MATLAB structure name

### DIFF
--- a/+bids/+internal/is_valid_fieldname.m
+++ b/+bids/+internal/is_valid_fieldname.m
@@ -1,0 +1,37 @@
+function status = is_valid_fieldname(some_str)
+  %
+  % A valid MATLAB identifier is a character vector of (A-Z, a-z, 0-9) and underscores,
+  % such that the first character is a letter and
+  % the length of the character vector is less than or equal to namelengthmax.
+  %
+  % USAGE::
+  %
+  %     status = is_valid_fieldname(some_str)
+  %
+  % (C) Copyright 2022 BIDS-MATLAB developers
+
+  namelengthmax = 63;
+
+  if ~ischar(some_str)
+    status = false;
+    return
+  end
+
+  if length(some_str) > namelengthmax
+    status = false;
+    return
+  end
+
+  invalid_characters = regexp(some_str, '[^a-zA-Z0-9_]', 'match');
+  if ~isempty(invalid_characters)
+    status = false;
+    return
+  end
+
+  invalid_first_characters = regexp(some_str(1), '[^a-zA-Z]', 'match');
+  if ~isempty(invalid_first_characters)
+    status = false;
+    return
+  end
+
+end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -128,10 +128,12 @@ function BIDS = layout(varargin)
 
     for iSess = 1:numel(sessions)
       if isempty(BIDS.subjects)
-        BIDS.subjects = parse_subject(BIDS.pth, subjects{iSub}, sessions{iSess}, schema, verbose);
+        BIDS.subjects = parse_subject(BIDS.pth, subjects{iSub}, sessions{iSess}, ...
+                                      schema, tolerant, verbose);
 
       else
-        new_subject = parse_subject(BIDS.pth, subjects{iSub}, sessions{iSess}, schema, verbose);
+        new_subject = parse_subject(BIDS.pth, subjects{iSub}, sessions{iSess}, ...
+                                    schema, tolerant, verbose);
         [BIDS.subjects, new_subject] = bids.internal.match_structure_fields(BIDS.subjects, ...
                                                                             new_subject);
         % TODO: this can be added to "match_structure_fields"
@@ -203,7 +205,7 @@ function BIDS = index_derivatives_dir(BIDS, idx_deriv, verbose)
   end
 end
 
-function subject = parse_subject(pth, subjname, sesname, schema, verbose)
+function subject = parse_subject(pth, subjname, sesname, schema, tolerant, verbose)
   %
   % Parse a subject's directory
   %
@@ -244,6 +246,17 @@ function subject = parse_subject(pth, subjname, sesname, schema, verbose)
         otherwise
           % in case we are going schemaless
           % or the modality is not one of the usual suspect
+
+          if ~bids.internal.is_valid_fieldname(modalities{iModality})
+            msg = sprintf('subject ''%s'' contains an invalid subfolder ''%s''. Skipping.', ...
+                          subject.path, ...
+                          modalities{iModality});
+            bids.internal.error_handling(mfilename, 'invalidSubfolderName', ...
+                                         msg, tolerant, verbose);
+            continue
+
+          end
+
           subject.(modalities{iModality}) = struct([]);
           subject = parse_using_schema(subject, modalities{iModality}, schema, verbose);
       end

--- a/miss_hit.cfg
+++ b/miss_hit.cfg
@@ -20,6 +20,6 @@ tab_width: 2
 
 # metrics limit for the code quality (https://florianschanda.github.io/miss_hit/metrics.html)
 metric "cnest": limit 5
-metric "file_length": limit 710
+metric "file_length": limit 750
 metric "cyc": limit 17
 metric "parameters": limit 8

--- a/tests/tests_layout/test_layout_derivatives.m
+++ b/tests/tests_layout/test_layout_derivatives.m
@@ -6,6 +6,20 @@ function test_suite = test_layout_derivatives %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_layout_warning_invalid_subfolder_struct_fieldname()
+
+  % https://github.com/bids-standard/bids-matlab/issues/332
+
+  invalid_subfolder = fullfile(get_test_data_dir(), '..', ...
+                               'data', 'synthetic', 'derivatives', 'invalid_subfolder');
+
+  assertWarning(@()bids.layout(invalid_subfolder, ...
+                               'use_schema', false, ...
+                               'verbose', true), ...
+                'layout:invalidSubfolderName');
+
+end
+
 function test_layout_nested()
 
   pth_bids_example = get_test_data_dir();


### PR DESCRIPTION
fix #332 