### PR TITLE
Alternate ix for the issue #470

### DIFF
--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -597,7 +597,6 @@ function BIDS = manage_dependencies(BIDS, verbose)
       end
       BIDS.subjects(info_dest.sub_idx).(info_dest.modality)(info_dest.file_idx) ...
           .dependencies.explicit{end + 1, 1} = file_list{iFile};
-      end
     end
 
   end

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -593,7 +593,7 @@ function BIDS = manage_dependencies(BIDS, verbose)
       if isempty(info_dest.file_idx)
         msg = ['IntendedFor file ' dest ' from ' file.filename ' not indexed'];
         bids.internal.error_handling(mfilename, 'IntendedForMissing', msg, tolerant, verbose);
-        continue;
+        continue
       end
       BIDS.subjects(info_dest.sub_idx).(info_dest.modality)(info_dest.file_idx) ...
           .dependencies.explicit{end + 1, 1} = file_list{iFile};

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -595,12 +595,13 @@ function BIDS = manage_dependencies(BIDS, verbose)
         continue
       end
       info_dest = bids.internal.return_file_info(BIDS, dest);
-      try
-        BIDS.subjects(info_dest.sub_idx).(info_dest.modality)(info_dest.file_idx) ...
-            .dependencies.explicit{end + 1, 1} = file_list{iFile};
-      catch ME
-        warning('This may fail if your dataset is not valid.');
-        rethrow(ME);
+      if isempty(info_dest.file_idx)
+        msg = ['IntendedFor file ' dest ' from ' file.filename ' not indexed'];
+        bids.internal.error_handling(mfilename, 'IntendedForMissing', msg, tolerant, verbose);
+        continue;
+      end
+      BIDS.subjects(info_dest.sub_idx).(info_dest.modality)(info_dest.file_idx) ...
+          .dependencies.explicit{end + 1, 1} = file_list{iFile};
       end
     end
 

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -589,11 +589,6 @@ function BIDS = manage_dependencies(BIDS, verbose)
     for iIntended = 1:numel(intended)
       dest = fullfile(BIDS.pth, BIDS.subjects(info_src.sub_idx).name, ...
                       intended{iIntended});
-      if ~exist(dest, 'file')
-        msg = ['IntendedFor file ' dest ' from ' file.filename ' not found'];
-        bids.internal.error_handling(mfilename, 'IntendedForMissing', msg, tolerant, verbose);
-        continue
-      end
       info_dest = bids.internal.return_file_info(BIDS, dest);
       if isempty(info_dest.file_idx)
         msg = ['IntendedFor file ' dest ' from ' file.filename ' not indexed'];


### PR DESCRIPTION
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/bids-standard/bids-matlab/pulls) for the same update/change?

Changes: replaced the test of existence of file referenced by IntendedFor field by test if it isindexed
is indexed (if `isempty(info_dest.file_idx)`).
Now it produces warning (if verbose) and skips the file:
```
Warning: IntendedFor file /Storage/beliy/bidsifications/osf/source/sub-01/fmap/sub-01_acq-headMTw_RB1COR.json from sub-01_magnitude1.nii not indexed
```

Removed the try/catch introduced in #471 as it may hide possible bugs and blame input datasets.

This try/catch can be re-introduced, but I feel it must protect full `manage_dependencies` function.

Making request draft, as there an alternative implementation of the fix #473.

Unclear how to implement the tests for these modifications, needs non-bids datasets...