### PR TITLE
[FIX] make download more robust when wget is not present

### DIFF
--- a/+bids/+internal/download.m
+++ b/+bids/+internal/download.m
@@ -25,10 +25,14 @@ function filename = download(URL, output_dir, verbose)
   if strcmp(protocol, 'http:')
 
     if isunix()
-      if verbose
-        system(sprintf('wget %s', URL));
-      else
-        system(sprintf('wget -q %s', URL));
+      try
+        if verbose
+          system(sprintf('wget %s', URL));
+        else
+          system(sprintf('wget -q %s', URL));
+        end
+      catch
+        urlwrite(URL, filename); %#ok<*URLWR>
       end
     else
       urlwrite(URL, filename);


### PR DESCRIPTION
related to https://github.com/cpp-lln-lab/bidspm/issues/803

demos fails when wget is not present