### PR TITLE
Fixes issue #476

### DIFF
--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -320,11 +320,11 @@ function copy_with_symlink(src, target, unzip_files, verbose)
     end
 
   elseif ispc
-    msg = 'Unknown system: copy may fail';
-    bids.internal.error_handling(mfilename, 'copyError', msg, true, verbose);
     use_copyfile(src, target, unzip_files, verbose);
 
   else
+    msg = 'Unknown system: copy may fail';
+    bids.internal.error_handling(mfilename, 'copyError', msg, true, verbose);
     use_copyfile(src, target, unzip_files, verbose);
 
   end


### PR DESCRIPTION
Addresses the issue #476 with excessive warnings during the copy to derivative under windows.

Moved warnings in `bids.copy_to_derivatice.m:307` from `if ispc` block to `else` block 