### PR TITLE
[INFRA] Use PAT to submit pull requests

### DIFF
--- a/.github/workflows/update_schema.yml
+++ b/.github/workflows/update_schema.yml
@@ -56,6 +56,7 @@ jobs:
         commit-message: BIDS schema update
         assignees: Remi-Gau
         base: master
+        token: ${{ secrets.PR_TOKEN }}
         delete-branch: true
         title: '[BOT] update schema'
         body: 'done via this [GitHub Action](https://github.com/bids-standard/bids-matlab/blob/master/.github/workflows/update_schema.yml)'


### PR DESCRIPTION
This will ensure that actions run on the PR. The default `GITHUB_TOKEN` is not enabled to do that to avoid a possible loop of new PRs with actions.

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/bids-standard/bids-matlab/pulls) for the same update/change?
