### PR TITLE
[DOC] specify the required version of gunzip for copying files on unix system

### DIFF
--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -29,6 +29,8 @@ function copy_to_derivative(varargin)
   %
   % :param unzip:           If ``true`` then all ``.gz`` files will be unzipped
   %                         after being copied.
+  %                         For MacOS and Unix system, this will require a
+  %                         version of gunzip >= 1.6.
   % :type  unzip:           logical
   %
   % :param force:           If set to ``false`` it will not overwrite any file already
@@ -304,9 +306,9 @@ function copy_with_symlink(src, target, unzip_files, verbose)
   if  isunix
 
     if unzip_files && is_gunzipped(src)
-      command = sprintf('gunzip -kfc %s > %s', src, target(1:end - 3));
+      command = sprintf('gunzip --keep --force --stdout %s > %s', src, target(1:end - 3));
     else
-      command = sprintf('cp -R -L -f %s %s', src, target);
+      command = sprintf('cp --recursive --dereference --force %s %s', src, target);
     end
 
     status = system(command);

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <!-- markdown-link-check-enable -->
 
 - [BIDS for MATLAB / Octave](#bids-for-matlab--octave)
+  - [Requirements](#requirements)
   - [Installation](#installation)
     - [Get the latest features](#get-the-latest-features)
   - [Features](#features)
@@ -22,7 +23,7 @@
     - [What will this toolbox most likely never do](#what-will-this-toolbox-most-likely-never-do)
   - [Usage](#usage)
   - [Demos](#demos)
-  - [Requirements](#requirements)
+  - [Requirements](#requirements-1)
     - [Reading and writing JSON files](#reading-and-writing-json-files)
   - [Implementation](#implementation)
   - [Get in touch](#get-in-touch)
@@ -38,6 +39,11 @@ For more information about BIDS, visit https://bids.neuroimaging.io/.
 
 See also [PyBIDS](https://github.com/bids-standard/pybids) for Python and the
 [BIDS Starter Kit](https://github.com/bids-standard/bids-starter-kit).
+
+## Requirements
+
+For MacOS and Unix system, using `bids.copy_to_derivative` requires
+a version of gunzip >= 1.6.
 
 ## Installation
 


### PR DESCRIPTION
closes #545 