### PR TITLE
[FIX] remove byte order mark from tsv file

### DIFF
--- a/+bids/+util/tsvread.m
+++ b/+bids/+util/tsvread.m
@@ -6,7 +6,7 @@ function file_content = tsvread(filename, field_to_return, hdr)
   %
   %   file_content = tsvread(filename, field_to_return, hdr)
   %
-  % :param filename: filename (can be gzipped) {txt,mat,csv,tsv,json}ename
+  % :param filename: filename (can be gzipped) {txt,mat,csv,tsv,json}
   % :type filename: string
   %
   % :param field_to_return: name of field to return if data stored in a structure
@@ -197,6 +197,10 @@ function x = dsv_read(filename, delim, header)
   end
   if S(end) ~= eol
     S = [S eol];
+  end
+  % Byte order mark (BOM),U+FEFF,0xEF,0xBB,0xBF
+  if S(1) == 65279
+    S(1) = [];
   end
   S = regexprep(S, {'\r\n', '\r', '(\n)\1+'}, {'\n', '\n', '$1'});
 

--- a/tests/tests_utils/test_tsvread.m
+++ b/tests/tests_utils/test_tsvread.m
@@ -37,6 +37,14 @@ function test_tsvread_basic()
 
 end
 
+function test_tsvread_bug_552()
+
+  tsv_file = fullfile(get_test_data_dir(), '..', 'data', 'bom_bug_552.tsv');
+  content = bids.util.tsvread(tsv_file);
+  assert(ismember('onset', fieldnames(content)));
+
+end
+
 function [pth, expected] = fixture()
 
   pth = fullfile(get_test_data_dir(), '..', 'data');


### PR DESCRIPTION
fix #552 