### PR TITLE
[ENH] remove checks for participants.tsv or samples.tsv in derivatives

### DIFF
--- a/+bids/+util/tsvwrite.m
+++ b/+bids/+util/tsvwrite.m
@@ -4,7 +4,7 @@ function tsvwrite(filename, var)
   %
   % USAGE::
   %
-  %   tsvwrite(f, var)
+  %   tsvwrite(filename, var)
   %
   % :param filename:
   % :type  filename: string

--- a/+bids/copy_to_derivative.m
+++ b/+bids/copy_to_derivative.m
@@ -159,8 +159,6 @@ function copy_to_derivative(varargin)
 
   ds_desc.write(derivatives_folder);
 
-  copy_participants_tsv(BIDS, derivatives_folder, args);
-
   % looping over selected files
   for iFile = 1:numel(data_list)
     copy_file(BIDS, derivatives_folder, data_list{iFile}, ...
@@ -176,23 +174,6 @@ function copy_to_derivative(varargin)
 
   copy_session_scan_tsv(BIDS, derivatives_folder, args);
 
-end
-
-function copy_participants_tsv(BIDS, derivatives_folder, args)
-  %
-  % Very "brutal" approach where we copy the whole file
-  %
-  % TODO: if only certain subjects are copied only copy those entries from the TSV
-  %
-
-  if ~isempty(BIDS.participants)
-
-    src = fullfile(BIDS.pth, 'participants.tsv');
-    target = fullfile(derivatives_folder, 'participants.tsv');
-
-    copy_tsv(src, target, args);
-
-  end
 end
 
 function copy_tsv(src, target, args)

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -138,9 +138,6 @@ function BIDS = layout(varargin)
   % [sourcedata/] - ignore
   % [phenotype/]
 
-  BIDS.participants = [];
-  BIDS.participants = manage_tsv(BIDS.participants, BIDS.pth, 'participants.tsv', verbose);
-
   BIDS = index_phenotype(BIDS);
 
   BIDS = index_root_directory(BIDS);
@@ -220,10 +217,7 @@ function BIDS = layout(varargin)
 
   BIDS = index_derivatives_dir(BIDS, index_derivatives, verbose);
 
-  if ismember('micr', bids.query(BIDS, 'modalities'))
-    BIDS.samples = [];
-    BIDS.samples = manage_tsv(BIDS.samples, BIDS.pth, 'samples.tsv', verbose);
-  end
+  BIDS = index_participants_and_sample(BIDS, verbose);
 
 end
 
@@ -256,6 +250,24 @@ function BIDS = index_phenotype(BIDS)
     if exist(sidecar, 'file') == 2
       BIDS.phenotype(i).metafile = sidecar;
     end
+  end
+end
+
+function BIDS = index_participants_and_sample(BIDS, verbose)
+  warn_for_missing_tsv = verbose;
+  if isfield(BIDS.description, 'DatasetType') && ...
+          strcmp(BIDS.description.DatasetType, 'derivative')
+    warn_for_missing_tsv = false;
+  end
+
+  BIDS.participants = [];
+  BIDS.participants = manage_tsv(BIDS.participants, BIDS.pth, ...
+                                 'participants.tsv', warn_for_missing_tsv);
+
+  if ismember('micr', bids.query(BIDS, 'modalities'))
+    BIDS.samples = [];
+    BIDS.samples = manage_tsv(BIDS.samples, BIDS.pth, ...
+                              'samples.tsv', warn_for_missing_tsv);
   end
 end
 

--- a/tests/test_bids_model.m
+++ b/tests/test_bids_model.m
@@ -180,9 +180,7 @@ end
 
 function test_model_validate()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   bm = bids.Model();
   bm.Nodes{1} = rmfield(bm.Nodes{1}, 'Name');

--- a/tests/tests_layout/test_layout.m
+++ b/tests/tests_layout/test_layout.m
@@ -8,6 +8,8 @@ end
 
 function test_warning_missing_participants_tsv()
 
+  skip_if_octave('mixed-string-concat warning thrown');
+
   bids_dir = fullfile(get_test_data_dir(), 'qmri_tb1tfl');
   assertWarning(@()bids.layout(bids_dir, ...
                                'verbose', true), ...
@@ -16,6 +18,8 @@ function test_warning_missing_participants_tsv()
 end
 
 function test_no_warning_missing_participants_tsv_derivatives()
+
+  skip_if_octave('mixed-string-concat warning thrown');
 
   bids_dir = fullfile(get_test_data_dir(), 'ds000001-fmriprep');
   try
@@ -56,9 +60,7 @@ end
 
 function test_layout_do_not_include_empty_subject_warning()
 
-  if bids.internal.is_octave() || ispc
-    moxunit_throw_test_skipped_exception('Octave mixed-string-concat or fail on windows');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   bids_dir = fullfile(get_test_data_dir(), 'qmri_tb1tfl');
   empty_sub = fullfile(bids_dir, 'sub-02');

--- a/tests/tests_layout/test_layout.m
+++ b/tests/tests_layout/test_layout.m
@@ -6,6 +6,29 @@ function test_suite = test_layout %#ok<*STOUT>
   initTestSuite;
 end
 
+function test_warning_missing_participants_tsv()
+
+  bids_dir = fullfile(get_test_data_dir(), 'qmri_tb1tfl');
+  assertWarning(@()bids.layout(bids_dir, ...
+                               'verbose', true), ...
+                'layout:tsvMissing');
+
+end
+
+function test_no_warning_missing_participants_tsv_derivatives()
+
+  bids_dir = fullfile(get_test_data_dir(), 'ds000001-fmriprep');
+  try
+    assertWarning(@()bids.layout(bids_dir, ...
+                                 'verbose', true, ...
+                                 'use_schema', false), ...
+                  'layout:tsvMissing');
+  catch ME
+    assert(strcmp(ME.identifier, 'moxunit:warningNotRaised'));
+  end
+
+end
+
 function test_layout_do_not_include_empty_subject()
 
   if ispc

--- a/tests/tests_layout/test_layout.m
+++ b/tests/tests_layout/test_layout.m
@@ -61,6 +61,10 @@ end
 function test_layout_do_not_include_empty_subject_warning()
 
   skip_if_octave('mixed-string-concat warning thrown');
+  if ispc
+    % TODO investigate
+    moxunit_throw_test_skipped_exception('fail on windows');
+  end
 
   bids_dir = fullfile(get_test_data_dir(), 'qmri_tb1tfl');
   empty_sub = fullfile(bids_dir, 'sub-02');

--- a/tests/tests_layout/test_layout_derivatives.m
+++ b/tests/tests_layout/test_layout_derivatives.m
@@ -125,9 +125,7 @@ function test_layout_warning_invalid_subfolder_struct_fieldname()
   invalid_subfolder = fullfile(get_test_data_dir(), '..', ...
                                'data', 'synthetic', 'derivatives', 'invalid_subfolder');
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   assertWarning(@()bids.layout(invalid_subfolder, ...
                                'use_schema', false, ...

--- a/tests/tests_private/test_append_to_layout.m
+++ b/tests/tests_private/test_append_to_layout.m
@@ -13,9 +13,7 @@ function test_layout_missing_subgroup()
   synthetic_derivatives = fullfile(get_test_data_dir(), '..', ...
                                    'data', 'synthetic', 'derivatives', 'manual');
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   assertWarning(@()bids.layout(synthetic_derivatives, 'verbose', true), ...
                 'append_to_layout:unknownSuffix');
@@ -24,9 +22,7 @@ end
 
 function test_append_to_layout_schema_unknown_entity()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   [subject, modality, schema, previous] = set_up('meg');
 
@@ -39,9 +35,7 @@ end
 
 function test_append_to_layout_schema_unknown_extension()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   [subject, modality, schema, previous] = set_up('meg');
 
@@ -91,9 +85,7 @@ end
 
 function test_append_to_layout_schema_missing_required_entity()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   [subject, modality, schema, previous] = set_up('func');
 

--- a/tests/tests_private/test_list_all_trial_types.m
+++ b/tests/tests_private/test_list_all_trial_types.m
@@ -32,9 +32,9 @@ function test_list_all_trial_types_warning()
   trial_type_list = bids.internal.list_all_trial_types(BIDS, {'not', 'a', 'task'}, ...
                                                        'verbose', false);
   assertEqual(trial_type_list, {});
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+
+  skip_if_octave('mixed-string-concat warning thrown');
+
   assertWarning(@() bids.internal.list_all_trial_types(BIDS, {'not', 'a', 'task'}, ...
                                                        'verbose', true), ...
                 'list_all_trial_types:noEventsFile');

--- a/tests/tests_private/test_parse_filename.m
+++ b/tests/tests_private/test_parse_filename.m
@@ -8,9 +8,7 @@ end
 
 function test_parse_filename_warnings()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   fields = {};
   tolerant = true;

--- a/tests/tests_private/test_return_file_index.m
+++ b/tests/tests_private/test_return_file_index.m
@@ -29,9 +29,7 @@ end
 
 function test_return_file_index_warning()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   pth_bids_example = get_test_data_dir();
 

--- a/tests/tests_utils/test_create_data_dict.m
+++ b/tests/tests_utils/test_create_data_dict.m
@@ -163,9 +163,7 @@ end
 
 function test_create_data_dict_warning
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   dataset = 'ds000248';
 

--- a/tests/tests_utils/test_create_participants_tsv.m
+++ b/tests/tests_utils/test_create_participants_tsv.m
@@ -22,9 +22,7 @@ end
 
 function test_create_participants_tsv_already_exist()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   bids_path = fullfile(get_test_data_dir(), 'ds210');
 

--- a/tests/tests_utils/test_create_readme.m
+++ b/tests/tests_utils/test_create_readme.m
@@ -26,9 +26,7 @@ end
 
 function test_create_readme_warning_already_present()
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   bids_path = fullfile(get_test_data_dir(), 'ds116');
 

--- a/tests/tests_utils/test_create_sessions_tsv.m
+++ b/tests/tests_utils/test_create_sessions_tsv.m
@@ -18,9 +18,7 @@ function test_create_sessions_tsv_no_session()
 
   validate_dataset(bids_path);
 
-  if bids.internal.is_octave()
-    moxunit_throw_test_skipped_exception('Octave:mixed-string-concat warning thrown');
-  end
+  skip_if_octave('mixed-string-concat warning thrown');
 
   assertWarning(@() bids.util.create_sessions_tsv(bids_path, 'verbose', true), ...
                 'create_sessions_tsv:noSessionInDataset');

--- a/tests/utils/skip_if_octave.m
+++ b/tests/utils/skip_if_octave.m
@@ -1,0 +1,6 @@
+function skip_if_octave(msg)
+  if bids.internal.is_octave()
+    moxunit_throw_test_skipped_exception(['Octave:', msg]);
+  end
+
+end


### PR DESCRIPTION
closes #665 

- do not copy participants.tsv to derivativates
- no warning for missing participants.tsv or samples.tsv in derivatives