### PR TITLE
Replace isdir and numel==1 with isfolder and isscalar

### DIFF
--- a/+bids/+internal/file_utils.m
+++ b/+bids/+internal/file_utils.m
@@ -51,7 +51,7 @@ function varargout = file_utils(str, varargin)
 
   str = cellstr(str);
 
-  if numel(options) == 1
+  if isscalar(options)
     [str, options] = get_item(str, options);
   end
 
@@ -282,7 +282,7 @@ function [files, dirs] = listfiles(action, directory, varargin)
 
     t = regexp(dirs, expr);
 
-    if numel(dirs) == 1 && ~iscell(t)
+    if isscalar(dirs) && ~iscell(t)
       t = {t};
     end
     dirs = dirs(~cellfun(@isempty, t));
@@ -291,7 +291,7 @@ function [files, dirs] = listfiles(action, directory, varargin)
   else
     t = regexp(files, expr);
 
-    if numel(files) == 1 && ~iscell(t)
+    if isscalar(files) && ~iscell(t)
       t = {t};
     end
     files = files(~cellfun(@isempty, t));

--- a/+bids/+internal/keep_file_for_query.m
+++ b/+bids/+internal/keep_file_for_query.m
@@ -70,7 +70,7 @@ function  status = check(status, file_struct, key, values)
 
   has_key = ismember(key, fields);
   % do we want to exclude the file (by passing an empty option) bassed on that key ?
-  exclude = numel(values) == 1 && isempty(values{1});
+  exclude = isscalar(values) && isempty(values{1});
 
   if ~has_key && ~exclude
     status = false;
@@ -135,7 +135,7 @@ end
 % and not for every call to keep_file
 
 function status = check_label_with_regex(value, option)
-  if numel(option) == 1
+  if isscalar(option)
     option = prepare_regex(option);
     keep = regexp(value, option, 'match');
     status = isempty(keep) || isempty(keep{1});

--- a/+bids/+internal/list_all_trial_types.m
+++ b/+bids/+internal/list_all_trial_types.m
@@ -33,7 +33,7 @@ function trial_type_list = list_all_trial_types(varargin)
   default_tolerant = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
 
   args = inputParser();
   addRequired(args, 'BIDS', is_dir_or_struct);

--- a/+bids/+internal/list_events.m
+++ b/+bids/+internal/list_events.m
@@ -32,7 +32,7 @@ function [data, headers, y_labels] = list_events(varargin)
 
   % (C) Copyright 2022 Remi Gau
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
 
   args = inputParser();
   addRequired(args, 'BIDS', is_dir_or_struct);

--- a/+bids/+internal/resolve_bids_uri.m
+++ b/+bids/+internal/resolve_bids_uri.m
@@ -69,7 +69,7 @@ function pth = resolve_bids_uri(uri, layout)
 
   end
 
-  if numel(pth) == 1
+  if isscalar(pth)
     pth = pth{1};
   end
 

--- a/+bids/+transformers_list/BaseTransformer.m
+++ b/+bids/+transformers_list/BaseTransformer.m
@@ -78,7 +78,7 @@ classdef BaseTransformer
       end
 
       assert(isstruct(transformer));
-      assert(numel(transformer) == 1);
+      assert(isscalar(transformer));
 
       if isfield(transformer, 'Input')
 
@@ -102,7 +102,7 @@ classdef BaseTransformer
       end
 
       assert(isstruct(transformer));
-      assert(numel(transformer) == 1);
+      assert(isscalar(transformer));
 
       if isfield(transformer, 'Output')
 

--- a/+bids/+transformers_list/Concatenate.m
+++ b/+bids/+transformers_list/Concatenate.m
@@ -26,7 +26,7 @@ function data = Concatenate(transformer, data)
     nb_rows(i) = size(data.(input{i}), 1); %#ok<AGROW>
   end
   nb_rows = unique(nb_rows);
-  assert(length(nb_rows) == 1);
+  assert(isscalar(nb_rows));
 
   for row = 1:nb_rows
 

--- a/+bids/+transformers_list/Constant.m
+++ b/+bids/+transformers_list/Constant.m
@@ -16,7 +16,7 @@ function data = Constant(transformer, data)
 
   output = bids.transformers_list.get_output(transformer, data);
 
-  assert(numel(output) == 1);
+  assert(isscalar(output));
 
   value = 1;
   if isfield(transformer, 'Value')

--- a/+bids/+transformers_list/Logical.m
+++ b/+bids/+transformers_list/Logical.m
@@ -41,7 +41,7 @@ function data = Logical(transformer, data)
   input = bids.transformers_list.get_input(transformer, data);
 
   output = bids.transformers_list.get_output(transformer, data);
-  assert(numel(output) == 1);
+  assert(isscalar(output));
 
   % try coerce all input to logical
   for i = 1:numel(input)

--- a/+bids/+transformers_list/Product.m
+++ b/+bids/+transformers_list/Product.m
@@ -26,7 +26,7 @@ function data = Product(transformer, data)
 
   output = bids.transformers_list.get_output(transformer, data);
 
-  assert(numel(output) == 1);
+  assert(isscalar(output));
 
   output = output{1};
 

--- a/+bids/+transformers_list/Scale.m
+++ b/+bids/+transformers_list/Scale.m
@@ -70,7 +70,7 @@ function data = Scale(transformer, data)
 
     nan_values = isnan(this_input);
 
-    if numel(unique(this_input)) == 1 && ismember(replace_na, {'off', 'before'})
+    if isscalar(unique(this_input)) && ismember(replace_na, {'off', 'before'})
       error(['Cannot scale a column with constant value %s\n', ...
              'If you want a constant column of 0 returned,\n'
              'set "replace_na" to "after"'], unique(this_input));

--- a/+bids/+transformers_list/Sum.m
+++ b/+bids/+transformers_list/Sum.m
@@ -34,7 +34,7 @@ function data = Sum(transformer, data)
 
   output = bids.transformers_list.get_output(transformer, data);
 
-  assert(numel(output) == 1);
+  assert(isscalar(output));
 
   output = output{1};
 

--- a/+bids/+transformers_list/get_input.m
+++ b/+bids/+transformers_list/get_input.m
@@ -5,7 +5,7 @@ function input = get_input(transformer, data)
   % (C) Copyright 2022 BIDS-MATLAB developers
 
   assert(isstruct(transformer));
-  assert(numel(transformer) == 1);
+  assert(isscalar(transformer));
 
   verbose = true;
   if isfield(transformer, 'verbose')

--- a/+bids/+util/create_participants_tsv.m
+++ b/+bids/+util/create_participants_tsv.m
@@ -29,7 +29,7 @@ function output_filename = create_participants_tsv(varargin)
   default_use_schema = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
   is_logical = @(x) islogical(x);
 
   args = inputParser();

--- a/+bids/+util/create_readme.m
+++ b/+bids/+util/create_readme.m
@@ -24,7 +24,7 @@ function create_readme(varargin)
   default_tolerant = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
   is_logical = @(x) islogical(x);
 
   args = inputParser();

--- a/+bids/+util/create_scans_tsv.m
+++ b/+bids/+util/create_scans_tsv.m
@@ -29,7 +29,7 @@ function output_filenames = create_scans_tsv(varargin)
   default_use_schema = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
   is_logical = @(x) islogical(x);
 
   args = inputParser();

--- a/+bids/+util/create_sessions_tsv.m
+++ b/+bids/+util/create_sessions_tsv.m
@@ -29,7 +29,7 @@ function output_filenames = create_sessions_tsv(varargin)
   default_use_schema = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
   is_logical = @(x) islogical(x);
 
   args = inputParser();

--- a/+bids/+util/jsonwrite.m
+++ b/+bids/+util/jsonwrite.m
@@ -76,7 +76,7 @@ function varargout = jsonwrite(varargin)
       opt      = varargin(2:end);
     end
   end
-  if numel(opt) == 1 && isstruct(opt{1})
+  if isscalar(opt) && isstruct(opt{1})
     opt = opt{1};
   elseif mod(numel(opt), 2) == 0
     opt = cell2struct(opt(2:2:end), opt(1:2:end), 2);
@@ -133,7 +133,7 @@ function S = jsonwrite_var(json, tab)
   elseif isnumeric(json) || islogical(json)
     S = jsonwrite_numeric(json);
   elseif isa(json, 'string')
-    if numel(json) == 1
+    if isscalar(json)
       if ismissing(json)
         S = 'null';
       else
@@ -143,7 +143,7 @@ function S = jsonwrite_var(json, tab)
       json = arrayfun(@(x)x, json, 'UniformOutput', false);
       json(cellfun(@(x) ismissing(x), json)) = {'null'};
       idx = find(size(json) ~= 1);
-      if numel(idx) == 1 % vector
+      if isscalar(idx) % vector
         S = jsonwrite_cell(json, tab);
       else % array
         S = jsonwrite_cell( ...
@@ -186,7 +186,7 @@ function S = jsonwrite_var(json, tab)
 
   % ==========================================================================
 function S = jsonwrite_struct(json, tab)
-  if numel(json) == 1
+  if isscalar(json)
     if isstruct(json)
       fn = fieldnames(json);
     else
@@ -221,7 +221,7 @@ function S = jsonwrite_struct(json, tab)
   % ==========================================================================
 function S = jsonwrite_cell(json, tab)
   if numel(json) == 0 || ...
-          (numel(json) == 1 && iscellstr(json)) || ...
+          (isscalar(json) && iscellstr(json)) || ...
           all(all(cellfun(@isnumeric, json))) || ...
           all(all(cellfun(@islogical, json)))
     tab = '';
@@ -260,7 +260,7 @@ function S = jsonwrite_numeric(json)
     return
   elseif numel(json) > 1
     idx = find(size(json) ~= 1);
-    if numel(idx) == 1 % vector
+    if isscalar(idx) % vector
       if any(islogical(json)) || any(~isfinite(json))
         S = jsonwrite_cell(num2cell(json), '');
       else

--- a/+bids/+util/tsvread.m
+++ b/+bids/+util/tsvread.m
@@ -126,7 +126,7 @@ function file_content = return_subset(file_content, field_to_return)
 
     if isempty(field_to_return)
       fieldsList = fieldnames(file_content);
-      if numel(fieldsList) == 1 && isnumeric(file_content.(fieldsList{1}))
+      if isscalar(fieldsList) && isnumeric(file_content.(fieldsList{1}))
         file_content = file_content.(fieldsList{1});
       end
 

--- a/+bids/Description.m
+++ b/+bids/Description.m
@@ -134,7 +134,7 @@ classdef Description
         value = varargin{2};
         obj.content(1).(key) = value;
 
-      elseif numel(varargin) == 1 && isstruct(varargin{1})
+      elseif isscalar(varargin) && isstruct(varargin{1})
         fields = fieldnames(varargin{1});
         for iField = 1:numel(fields)
           key = fields{iField};

--- a/+bids/Model.m
+++ b/+bids/Model.m
@@ -363,7 +363,7 @@ classdef Model
       function value = format_output(value, idx)
         if ~iscell(value) && numel(idx) > 1
           value = {value};
-        elseif iscell(value) && numel(value) == 1
+        elseif iscell(value) && isscalar(value)
           value = value{1};
         end
       end
@@ -479,7 +479,7 @@ classdef Model
                                      obj.verbose);
       end
 
-      if numel(edge) == 1
+      if isscalar(edge)
         edge = edge{1};
       end
 
@@ -694,7 +694,7 @@ classdef Model
       %
       value = [];
       [node, idx] = get_nodes(obj, varargin{:});
-      assert(numel(node) == 1);
+      assert(isscalar(node));
       if isfield(node, 'Transformations')
         value = node.Transformations;
       end
@@ -711,7 +711,7 @@ classdef Model
       %
       value = [];
       [node, idx] = get_nodes(obj, varargin{:});
-      assert(numel(node) == 1);
+      assert(isscalar(node));
       if isfield(node, 'DummyContrasts')
         value = node.DummyContrasts;
       end
@@ -728,7 +728,7 @@ classdef Model
       %
       value = [];
       [node, idx] = get_nodes(obj, varargin{:});
-      assert(numel(node) == 1);
+      assert(isscalar(node));
       if isfield(node, 'Contrasts')
         value = node.Contrasts;
       end
@@ -744,7 +744,7 @@ classdef Model
       % :type Name: char
       %
       [node, idx] = get_nodes(obj, varargin{:});
-      assert(numel(node) == 1);
+      assert(isscalar(node));
       value = node.Model;
     end
 
@@ -789,7 +789,7 @@ classdef Model
       %   bm.write(filename);
       %
 
-      is_dir_or_struct = @(x) isstruct(x) || isdir(x);  %#ok<*ISDIR>
+      is_dir_or_struct = @(x) isstruct(x) || isfolder(x);
       is_char_or_cellstr = @(x) ischar(x) || iscellstr(x); %#ok<*ISCLSTR>
 
       args = inputParser;
@@ -876,7 +876,7 @@ classdef Model
 
         this_node = obj.content.Nodes{i};
 
-        if isnumeric(this_node.Model.X) && numel(this_node.Model.X) == 1
+        if isnumeric(this_node.Model.X) && isscalar(this_node.Model.X)
           this_node.Model.X = {this_node.Model.X};
         end
 
@@ -887,12 +887,12 @@ classdef Model
 
             if ~isempty(this_contrast.Weights) && ...
                 ~iscell(this_contrast.Weights) && ...
-                numel(this_contrast.Weights) == 1
+                isscalar(this_contrast.Weights)
               this_contrast.Weights = {this_contrast.Weights};
             end
 
             if isnumeric(this_contrast.ConditionList) && ...
-                numel(this_contrast.ConditionList) == 1
+                isscalar(this_contrast.ConditionList)
               this_contrast.ConditionList = {this_contrast.ConditionList};
             end
 

--- a/+bids/Schema.m
+++ b/+bids/Schema.m
@@ -335,7 +335,7 @@ classdef Schema
       idx = ismember(keys, entity_key);
       entity_name = all_names(idx);
 
-      if numel(entity_name) == 1
+      if isscalar(entity_name)
         entity_name = entity_name{1};
       end
 
@@ -376,7 +376,7 @@ classdef Schema
         keys{i} = obj.content.objects.entities.(entity).name;
       end
 
-      if numel(keys) == 1
+      if isscalar(keys)
         keys = keys{1};
       end
 

--- a/+bids/layout.m
+++ b/+bids/layout.m
@@ -71,7 +71,7 @@ function BIDS = layout(varargin)
   default_use_schema = true;
   default_verbose = false;
 
-  is_dir_or_struct = @(x) (isstruct(x) || isdir(x));
+  is_dir_or_struct = @(x) (isstruct(x) || isfolder(x));
 
   args = inputParser();
 
@@ -153,7 +153,7 @@ function BIDS = layout(varargin)
   end
 
   BIDS.is_datalad_ds = false;
-  if isdir(fullfile(BIDS.pth, '.datalad')) && isdir(fullfile(BIDS.pth, '.git'))
+  if isfolder(fullfile(BIDS.pth, '.datalad')) && isfolder(fullfile(BIDS.pth, '.git'))
     BIDS.is_datalad_ds = true;
   end
 
@@ -287,7 +287,7 @@ function value = exclude(filter, entity, label)
     return
   end
   % use regex when filter is a cell of numel 1
-  if numel(filter.(entity)) == 1
+  if isscalar(filter.(entity))
     if cellfun('isempty', regexp(label, filter.(entity)))
       value = true;
     end

--- a/+bids/query.m
+++ b/+bids/query.m
@@ -219,7 +219,7 @@ function result = query(BIDS, query, varargin)
       result = result';
 
     case {'metadata', 'dependencies'}
-      if numel(result) == 1
+      if isscalar(result)
         result = result{1};
       else
         result = result';
@@ -302,7 +302,7 @@ end
 
 function options = parse_query(options)
 
-  if numel(options) == 1
+  if isscalar(options)
 
     if isstruct(options{1})
       options = [fieldnames(options{1}), struct2cell(options{1})];
@@ -642,7 +642,7 @@ end
 % and not for every call to keep_file
 
 function status = check_label_with_regex(label, option)
-  if numel(option) == 1
+  if isscalar(option)
     option = prepare_regex(option);
     keep = regexp(label, option, 'match');
     status = isempty(keep) || isempty(keep{1});

--- a/demos/spm/facerep/code/spm_facerep.m
+++ b/demos/spm/facerep/code/spm_facerep.m
@@ -21,7 +21,7 @@ subject_label = '01';
 %% Download
 
 % clean previously failed download
-if isdir(fullfile(pwd, '..', 'face_rep'))
+if isfolder(fullfile(pwd, '..', 'face_rep'))
   rmdir(fullfile(pwd, '..', 'face_rep'), 's');
 end
 

--- a/tests/test_copy_to_derivative.m
+++ b/tests/test_copy_to_derivative.m
@@ -332,7 +332,7 @@ function [BIDS, out_path, filter, cfg] = fixture(dataset)
 
       BIDS = moae_dir();
 
-      if ~isdir(fullfile(BIDS, 'sub-01'))
+      if ~isfolder(fullfile(BIDS, 'sub-01'))
 
         bids.util.download_ds('source', 'spm', ...
                               'demo', 'moae', ...


### PR DESCRIPTION
Updated all instances of the deprecated isdir function to use isfolder for directory checks. Replaced numel(x) == 1 with isscalar(x) for scalar checks throughout the codebase, improving code clarity and compatibility with newer MATLAB versions.

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/bids-standard/bids-matlab/pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [x] Have you lint your code locally prior to submission?

### Changes to Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
