### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
 - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,10 @@
----
-# Documentation
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: semiannually
+  groups:
+    actions-infrastructure:
+      patterns:
+      - actions/*


### PR DESCRIPTION
Adds a `groups` section to .github/dependabot.yml so dependabot PRs are grouped per ecosystem, matching the convention applied across other repos.